### PR TITLE
Change my name link to my personal website?

### DIFF
--- a/interactives/mips-assembler/README.md
+++ b/interactives/mips-assembler/README.md
@@ -7,7 +7,7 @@ This interactive allows users to enter MIPS code to see the assembler output.
 
 ## MIPS Assembler License
 
-The [MIPS Assembler](https://github.com/alanhogan/online-mips-assembler) by [Alan Hogan](https://github.com/alanhogan) is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
+The [MIPS Assembler](https://github.com/alanhogan/online-mips-assembler) by [Alan Hogan](http://alanhogan.com/) is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
 
 
 ## Required Files


### PR DESCRIPTION
Hey, this isn't a big deal either way. Maybe the thought here was that a github page would be more reliably safe for school than a personal website?

([Usually true](http://gizmodo.com/saucy-coder-scheduled-out-his-github-activity-to-spell-1586577467).)
![cccr6une3ldlxgfuwbdu](https://cloud.githubusercontent.com/assets/6808/13560408/a7204acc-e3d3-11e5-8789-3340666b9295.png)

It’s OK if you don’t change it, but I chose to have my own domain as my canonical identity online, over a profile on a third-party service.

Thoughts welcome.