### PR TITLE
Typo

### DIFF
--- a/text/en/chapters/human-computer-interaction.md
+++ b/text/en/chapters/human-computer-interaction.md
@@ -478,7 +478,7 @@ In general it's good for the computer to "remember" details, and the user to be 
 The exception is a system that is used all the time by an expert who knows all the options; in this case entering commands directly can sometimes be more flexible and faster than having to select from a list.
 
 For example, when you type in a place name in an online map, the system might start suggesting names based on what you're typing, and probably adapted to focus on your location or past searches.
-The following image is from Google maps, which suggests the name of the place you may be trying to type (in this case, the user has only had to type 4 letters, and the system saves them from having the recall the correct spelling of "Taumatawhakatangihangakoauauotamateapokaiwhenuakitanatahu" because they can then select it.)
+The following image is from Google maps, which suggests the name of the place you may be trying to type (in this case, the user has only had to type 4 letters, and the system saves them from having to recall the correct spelling of "Taumatawhakatangihangakoauauotamateapokaiwhenuakitanatahu" because they can then select it.)
 A similar feature in web browsers saves users from having to remember the exact details of a URL that they have used in the past; a system that required you to type in place names exactly before you could search for them could get rather frustrating.
 
 {image filename="recognition-place-names.png" alt="Map predicting possible place names"}


### PR DESCRIPTION
Typo. Should be a preposition instead of a definite article.