### PR TITLE
Fix #134: Center images

### DIFF
--- a/generator/scss/third-party/components/_global.scss
+++ b/generator/scss/third-party/components/_global.scss
@@ -129,6 +129,7 @@ i {
 // Images
 img.responsive-img,
 video.responsive-video {
+  display: inline-block;
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
Changes:
* Make images display as `inline-block` instead of `block`, so they center properly in their parent div.

To test:

1. Go to output/en/chapters/human-computer-interaction.html#visibility-of-system-status
1. Note the progress indicator images (and all others) are now properly horizontally centered
1. View the same page in mobile layout and note that the images are now centered