### PR TITLE
Interactive/high score boxes

### DIFF
--- a/interactives/high-score-boxes/css/style.css
+++ b/interactives/high-score-boxes/css/style.css
@@ -10,6 +10,7 @@ div.box {
     background-color: white;
     z-index: 3;
     background-size: contain;
+    cursor: pointer;
 
 
 }

--- a/interactives/high-score-boxes/css/style.css
+++ b/interactives/high-score-boxes/css/style.css
@@ -15,6 +15,11 @@ div.box {
 
 }
 
+.clicked {
+    -webkit-filter: grayscale(100%); /* Chrome, Safari, Opera */
+    filter: grayscale(100%);
+}
+
 div.intHoldingDiv {
 	width: 100px;
 	height: 100px;

--- a/interactives/high-score-boxes/css/style.css
+++ b/interactives/high-score-boxes/css/style.css
@@ -30,6 +30,13 @@ div.intHoldingDiv {
 	font-size: 1.5rem;
 	font-weight: bold;
 
+	/*disabling dragging/selecting*/
+    -WEBKIT-USER-SELECT: NONE; /* SAFARI, CHROME */
+    -KHTML-USER-SELECT: NONE; /* KONQUEROR */
+    -MOZ-USER-SELECT: NONE; /* FIREFOX */
+    -MS-USER-SELECT: NONE; /* IE */
+    USER-SELECT: NONE; /* CSS3 */
+
 }
 
 div.boxContainer {

--- a/interactives/high-score-boxes/css/style.css
+++ b/interactives/high-score-boxes/css/style.css
@@ -12,6 +12,13 @@ div.box {
     background-size: contain;
     cursor: pointer;
 
+        /*disabling dragging/selecting*/
+    -WEBKIT-USER-SELECT: NONE; /* SAFARI, CHROME */
+    -KHTML-USER-SELECT: NONE; /* KONQUEROR */
+    -MOZ-USER-SELECT: NONE; /* FIREFOX */
+    -MS-USER-SELECT: NONE; /* IE */
+    USER-SELECT: NONE; /* CSS3 */
+
 
 }
 
@@ -35,12 +42,7 @@ div.intHoldingDiv {
 	font-size: 1.5rem;
 	font-weight: bold;
 
-	/*disabling dragging/selecting*/
-    -WEBKIT-USER-SELECT: NONE; /* SAFARI, CHROME */
-    -KHTML-USER-SELECT: NONE; /* KONQUEROR */
-    -MOZ-USER-SELECT: NONE; /* FIREFOX */
-    -MS-USER-SELECT: NONE; /* IE */
-    USER-SELECT: NONE; /* CSS3 */
+
 
 }
 
@@ -53,6 +55,13 @@ div.boxContainer {
     margin-bottom: 40px;
     margin-right: 20px;
     margin-left: 20px;
+
+        /*disabling dragging/selecting*/
+    -WEBKIT-USER-SELECT: NONE; /* SAFARI, CHROME */
+    -KHTML-USER-SELECT: NONE; /* KONQUEROR */
+    -MOZ-USER-SELECT: NONE; /* FIREFOX */
+    -MS-USER-SELECT: NONE; /* IE */
+    USER-SELECT: NONE; /* CSS3 */
 }
 
 #restartButton {

--- a/interactives/high-score-boxes/index.html
+++ b/interactives/high-score-boxes/index.html
@@ -19,7 +19,7 @@
     <!-- ### Start of required HTML for inline interactives ### -->
     <div class="interactive" id="interactive-high-score-boxes">
     <h1>High Score Boxes</h1>
-    <p>Clicking a box will reveal its number; your task is to find the highest number. </p>
+    <p>Clicking a box will reveal its number; your task is to find the highest number and enter it below. </p>
     <div class="row">
     	<div class="col s12">
 			<div id="box_holder_div">

--- a/interactives/high-score-boxes/index.html
+++ b/interactives/high-score-boxes/index.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <div class="row">
-    <div class="col s12 m8 l6 offset-l3 offset-m2">
+    <div class="col s12 m10 l8 offset-l2 offset-m2">
     <!-- ### Start of required HTML for inline interactives ### -->
     <div class="interactive" id="interactive-high-score-boxes">
     <h1>High Score Boxes</h1>

--- a/interactives/high-score-boxes/index.html
+++ b/interactives/high-score-boxes/index.html
@@ -19,7 +19,7 @@
     <!-- ### Start of required HTML for inline interactives ### -->
     <div class="interactive" id="interactive-high-score-boxes">
     <h1>High Score Boxes</h1>
-    <p>What is the largest number in the boxes? </p>
+    <p>Clicking a box will reveal its number; your task is to find the highest number. </p>
     <div class="row">
     	<div class="col s12">
 			<div id="box_holder_div">

--- a/interactives/high-score-boxes/js/findHighScore.js
+++ b/interactives/high-score-boxes/js/findHighScore.js
@@ -1,7 +1,7 @@
 //onload make array of 5 random ints
 this.randomInts = [];
 this.largest = 0;
-this.numberOfBoxes = 3
+this.numberOfBoxes = 15
 this.boxes = []
 this.gameStarted = false;
 this.secondsTaken = 0;
@@ -34,12 +34,15 @@ $(document).ready(function(){
 })
 
 $(document).on('click','.box', function (event) {
+	var filterVal = 'grayscale(100)';
+
 	$(".box").stop(true, true);
 	$(".box").show();
 	for (var i = 0; i < (boxes.length); i++) { 
 		if (document.getElementById('box' + i) ==  event.target) {
 			$(this).fadeOut(1000);
-			$(this).fadeTo(1000, 0.5);
+			$(this).fadeIn(1000);
+			$(this).addClass( "clicked" );
 			boxes[i].revealed_times += 1;
 		}
 	}

--- a/interactives/high-score-boxes/js/findHighScore.js
+++ b/interactives/high-score-boxes/js/findHighScore.js
@@ -85,6 +85,9 @@ function generateRandomNumbers() {
 }
 
 function createBoxElements() {
+
+	var range = Array.apply(null, Array(15)).map(function (_, i) {return i;});
+	shuffle(range);
 	for (var i = 0; i < (numberOfBoxes); i++) {
 		var boxObject; //JS object that will hold the id, int and both elements
 		var currentBox = boxes[i]
@@ -120,7 +123,8 @@ function createBoxElements() {
 
 
 		//set background image of div to the funky box
-		boxDiv.style.backgroundImage = 'url(./img/square' + getRandomInt(1, 9) + '.png)';
+		var boxImageIndex = range[i] + 1;
+		boxDiv.style.backgroundImage = 'url(./img/square' + boxImageIndex + '.png)';
 
 		currentBox.divElement = boxDiv;
 		iContainer.appendChild(boxDiv);

--- a/interactives/high-score-boxes/js/findHighScore.js
+++ b/interactives/high-score-boxes/js/findHighScore.js
@@ -1,7 +1,7 @@
 //onload make array of 5 random ints
 this.randomInts = [];
 this.largest = 0;
-this.numberOfBoxes = 15
+this.numberOfBoxes = 3
 this.boxes = []
 this.gameStarted = false;
 this.secondsTaken = 0;
@@ -39,7 +39,7 @@ $(document).on('click','.box', function (event) {
 	for (var i = 0; i < (boxes.length); i++) { 
 		if (document.getElementById('box' + i) ==  event.target) {
 			$(this).fadeOut(1000);
-			$(this).fadeIn(1000);
+			$(this).fadeTo(1000, 0.5);
 			boxes[i].revealed_times += 1;
 		}
 	}
@@ -61,10 +61,23 @@ function myTimer() {
 }
 
 function generateRandomNumbers() {
-		for (var i = 0; i < (numberOfBoxes); i++) {
-		var currentInt = getRandomInt(300, 800);
+	var intervals = [0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+	shuffle(intervals);
+
+	var twoIntervals = intervals.slice(0, 2);
+	twoIntervals.sort();
+
+	for (var i = 0; i < (numberOfBoxes); i++) {
+
+		var currentInt = getRandomInt(twoIntervals[0], twoIntervals[1]);
+		while (randomInts.indexOf(currentInt) != -1) {
+			var currentInt = getRandomInt(twoIntervals[0], twoIntervals[1]);
+		}
+
 		randomInts[i] = currentInt;
 	}
+	console.log(twoIntervals[0] +" " + twoIntervals[1])
+
 	largest = Math.max.apply(Math, randomInts);
 }
 
@@ -137,6 +150,20 @@ function createBoxObjects() {
 
 function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min)) + min;
+}
+
+/**
+ * Shuffles array in place.
+ * @param {Array} a items The array containing the items.
+ */
+function shuffle(a) {
+    var j, x, i;
+    for (i = a.length; i; i--) {
+        j = Math.floor(Math.random() * i);
+        x = a[i - 1];
+        a[i - 1] = a[j];
+        a[j] = x;
+    }
 }
 
 //form validation

--- a/interactives/high-score-boxes/js/findHighScore.js
+++ b/interactives/high-score-boxes/js/findHighScore.js
@@ -33,7 +33,7 @@ $(document).ready(function(){
 	})
 })
 
-$(document).on('click','.box', function() {
+$(document).on('click','.box', function (event) {
 	$(".box").stop(true, true);
 	$(".box").show();
 	for (var i = 0; i < (boxes.length); i++) { 
@@ -75,6 +75,7 @@ function createBoxElements() {
 
 		//"container" div
 		var iContainer = document.createElement('div');
+		iContainer.draggable = false;
 		iContainer.id = ('boxContainer' + i);
 		iContainer.className = 'boxContainer';
 		document.getElementById('box_holder_div').appendChild(iContainer);
@@ -95,6 +96,8 @@ function createBoxElements() {
 
 		//"box (covering the div holding number"
 		var boxDiv = document.createElement('div');
+		boxDiv.draggable = false;
+
 		boxDiv.id = ('box' + i);
 		boxDiv.className = 'box';
 		boxDiv.setAttribute("width", "100");
@@ -108,6 +111,8 @@ function createBoxElements() {
 
 		//divs that hold the numbers
 		var intHoldingDiv = document.createElement('div');
+		intHoldingDiv.draggable = false;
+
 		intHoldingDiv.id = ('intHoldingDiv' + i);
 		intHoldingDiv.className = 'intHoldingDiv';
 		intHoldingDiv.innerHTML = currentBox.boxInt;


### PR DESCRIPTION
## Proposed changes

All bugs that were found during the EDEM session have been fixed, including:
 - Firefox compatibility
 - All numbers being revealed on dragging (disable dragging)
 - Range of random numbers is different each time now (to stop users "guessing" on repeated playthroughs
 - Added some new box images so users don't attempt to relate any of them together
 - boxes go greyscale on click (so users know which ones have been clicked)
 







### Checklist

*Put an `x` in the boxes that apply. You can also fill these out after creating the pull request. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change.*

- [x] I have read the [contribution guidelines](.github/CONTRIBUTING.md)
- [ ] I have linked any relevant [existing issues/suggestions](https://github.com/uccser/cs-field-guide/issues) in the description above (include `#???` in your description to reference an issue, where `???` is the issue number)
- [ ] I have applied the relevant labels for this change
- [ ] I have run the generation script and checked the output
- [ ] I have added necessary documentation (if appropriate)

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. Feel free to add any images that might be helpful to understand the initial problem/solution.
