### PR TITLE
Handle digits in 2d-arrow-manipulation config name

### DIFF
--- a/interactives/2d-arrow-manipulations/js/main.js
+++ b/interactives/2d-arrow-manipulations/js/main.js
@@ -52,7 +52,7 @@ window.onload = function(event) {
 
     // gets name of config file according to url parameter
     var url = window.location.search.replace('?', '');
-    var configFileRegex = /config=((matrix|coord)-([a-z]*|-)*)/g;
+    var configFileRegex = /config=((matrix|coord)-(\w*|-)*)/g;
     var configFile = configFileRegex.exec(url)[1];
     var filename = 'config/' + configFile + '.json';
 


### PR DESCRIPTION
There is a bug in `2d-arrow-manipulations` interactive that occurs when using config names including digits, e.g. `matrix-scale-translate-2`. It is caused by a faulty regex that matches incomplete label and makes the script look for a non-existent config file.

This PR fixes that.