### PR TITLE
Updated Delay Analyser reset button #413

### DIFF
--- a/interactives/delay-analyser/css/delay-analyser.css
+++ b/interactives/delay-analyser/css/delay-analyser.css
@@ -52,3 +52,6 @@
   color: red;
   font-weight: bold;
 }
+#reset {
+  margin: 40px;
+}


### PR DESCRIPTION
I increased the margin from the reset button so that it is further away from the grid.

The request to do this came from: 
https://github.com/uccser/cs-field-guide/issues/413

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request:
Just like JackMorganNZ suggested, I believe that the button is too close to the Delay Analyser and people can accidentally click on the reset button. We should move it just a little bit so that people won't reset it by mistake.  I also believe that this change makes the page looks much nicer.

This is my first pull request on Github and I appreciate you taking the time to look over this. I look forward to potentially running more fixes through this Github account.

Best regards,
jamierobertdawson@gmail.com


### Checklist

*Put an `x` in the boxes that apply. You can also fill these out after creating the pull request. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change.*

- [ x] I have read the [contribution guidelines](.github/CONTRIBUTING.md)
- [x ] I have linked any relevant [existing issues/suggestions](https://github.com/uccser/cs-field-guide/issues) in the description above (include `#???` in your description to reference an issue, where `???` is the issue number)
- [x ] I have applied the relevant labels for this change
- [x ] I have run the generation script and checked the output
- [x ] I have added necessary documentation (if appropriate)

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc. Feel free to add any images that might be helpful to understand the initial problem/solution.
