### PR TITLE
Fix typo in section 2.1.3

### DIFF
--- a/text/en/chapters/algorithms.md
+++ b/text/en/chapters/algorithms.md
@@ -147,7 +147,7 @@ Here is an algorithm for assigning animals as pets to people on a waitlist:
 This algorithm relies on a correct search algorithm in the first step.
 If the search algorithm incorrectly chose a random person, the algorithm for assigning animals as pets would also be incorrect.
 
-As you will see in this chapter with searching and sorting there exist multiple correct algorithms for the same problem.
+As you will see in this chapter with searching and sorting there are multiple correct algorithms for the same problem.
 Often there are good reasons to know multiple correct algorithms because there are tradeoffs in simplicity, algorithm cost, and assumptions about inputs.
 
 ### Searching and Sorting


### PR DESCRIPTION
## Proposed changes

Fix a typo in section 2.1.3 (Algorithm Correctness)

Changed: 
```diff
- with searching and sorting there exist multiple correct algorithms for the same problem.
+ with searching and sorting there are multiple correct algorithms for the same problem.
```




### Checklist

- [x] I have read the [contribution guidelines](.github/CONTRIBUTING.md)
- [x] I have linked any relevant [existing issues/suggestions](https://github.com/uccser/cs-field-guide/issues) in the description above (include `#???` in your description to reference an issue, where `???` is the issue number)
- [ ] I have applied the relevant labels for this change
- [x] I have run the generation script and checked the output
- [ ] I have added necessary documentation (if appropriate)

