### PR TITLE
Use unique port number for CSFG development

### DIFF
--- a/csfg
+++ b/csfg
@@ -68,7 +68,7 @@ cmd_start() {
   cmd_update
   # Alert user that system is ready
   echo -e "\n${GREEN}Systems are ready!${NC}"
-  echo "Open your preferred web browser to the URL 'localhost'"
+  echo "Open your preferred web browser to the URL 'localhost:81'"
 }
 
 defhelp start 'Start development environment (this also runs the update command).'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,4 +31,4 @@ services:
     depends_on:
       - django
     ports:
-      - "80:80"
+      - "81:80"


### PR DESCRIPTION
This pull request uses a unique port number for viewing the cs-field-guide website, when also working on the cs-unplugged project.