### PR TITLE
Fix computed value

### DIFF
--- a/interactives/base-calculator/js/base-calculator.js
+++ b/interactives/base-calculator/js/base-calculator.js
@@ -22,7 +22,7 @@ $(document).ready(function () {
             column.find('.orignal-value').text(parseInt(select.val(), baseCalculatorSettings.BASE));
         }
         if (baseCalculatorSettings.SHOW_VALUE) {
-            column.find('.computed-value').text(select.data('value'));
+            column.find('.computed-value').text(select.val() * select.data('value'));
         }
         updateTotalColumn(baseCalculatorSettings);
     });


### PR DESCRIPTION
Computed value is not correctly shown since it only shows the power of
base in certain place. For example when using calculator with base 10 it
shows only 1, 10, 100, 1000 etc. instead of seleted value in drop-down
multiplied with either 1, 10, 100, 1000 etc. depending on the place in the
number.
