### PR TITLE
Disable content that is not converted

### DIFF
--- a/csfieldguide/chapters/content/structure/structure.yaml
+++ b/csfieldguide/chapters/content/structure/structure.yaml
@@ -1,35 +1,35 @@
 chapters:
   introduction:
     chapter-number: 1
-  algorithms:
-    chapter-number: 2
-  programming-languages:
-    chapter-number: 3
-  human-computer-interaction:
-    chapter-number: 4
-  data-representation:
-    chapter-number: 5
-  coding-introduction:
-    chapter-number: 6
-  coding-compression:
-    chapter-number: 7
-  coding-encryption:
-    chapter-number: 8
-  coding-error-control:
-    chapter-number: 9
-  artificial-intelligence:
-    chapter-number: 10
-  complexity-and-tractability:
-    chapter-number: 11
-  computer-graphics:
-    chapter-number: 12
-  computer-vision:
-    chapter-number: 13
-  formal-languages:
-    chapter-number: 14
-  network-communication-protocols:
-    chapter-number: 15
-  software-engineering:
-    chapter-number: 16
+  # algorithms:
+  #   chapter-number: 2
+  # programming-languages:
+  #   chapter-number: 3
+  # human-computer-interaction:
+  #   chapter-number: 4
+  # data-representation:
+  #   chapter-number: 5
+  # coding-introduction:
+  #   chapter-number: 6
+  # coding-compression:
+  #   chapter-number: 7
+  # coding-encryption:
+  #   chapter-number: 8
+  # coding-error-control:
+  #   chapter-number: 9
+  # artificial-intelligence:
+  #   chapter-number: 10
+  # complexity-and-tractability:
+  #   chapter-number: 11
+  # computer-graphics:
+  #   chapter-number: 12
+  # computer-vision:
+  #   chapter-number: 13
+  # formal-languages:
+  #   chapter-number: 14
+  # network-communication-protocols:
+  #   chapter-number: 15
+  # software-engineering:
+  #   chapter-number: 16
 
 glossary-folder: glossary

--- a/csfieldguide/interactives/content/structure/interactives.yaml
+++ b/csfieldguide/interactives/content/structure/interactives.yaml
@@ -1,186 +1,186 @@
-2d-arrow-manipulations:
-  languages:
-    en: interactives/2d-arrow-manipulations.html
-action-menu:
-  languages:
-    en: interactives/action-menu.html
-available-menu-items:
-  languages:
-    en: interactives/available-menu-items.html
+# 2d-arrow-manipulations:
+#   languages:
+#     en: interactives/2d-arrow-manipulations.html
+# action-menu:
+#   languages:
+#     en: interactives/action-menu.html
+# available-menu-items:
+#   languages:
+#     en: interactives/available-menu-items.html
 awful-calculator:
   languages:
     en: interactives/awful-calculator.html
-base-calculator:
-  languages:
-    en: interactives/base-calculator.html
-big-number-calculator:
-  languages:
-    en: interactives/big-number-calculator.html
-bin-packing:
-  languages:
-    en: interactives/bin-packing.html
-binary-cards:
-  languages:
-    en: interactives/binary-cards.html
-box-rotation:
-  languages:
-    en: interactives/box-rotation.html
-box-translation:
-  languages:
-    en: interactives/box-translation.html
-caesar-cipher:
-  languages:
-    en: interactives/caesar-cipher.html
-checksum-calculator:
-  languages:
-    en: interactives/checksum-calculator.html
-checksum-calculator-gtin-13:
-  languages:
-    en: interactives/checksum-calculator-gtin-13.html
-close-window:
-  languages:
-    en: interactives/close-window.html
-cmy-mixer:
-  languages:
-    en: interactives/cmy-mixer.html
-colour-matcher:
-  languages:
-    en: interactives/colour-matcher.html
-compression-comparer:
-  languages:
-    en: interactives/compression-comparer.html
-confused-buttons:
-  languages:
-    en: interactives/confused-buttons.html
-date-picker:
-  languages:
-    en: interactives/date-picker.html
-deceiver:
-  languages:
-    en: interactives/deceiver.html
-delay-analyser:
-  languages:
-    en: interactives/delay-analyser.html
-delayed-checkbox:
-  languages:
-    en: interactives/delayed-checkbox.html
-frequency-analysis:
-  languages:
-    en: interactives/frequency-analysis.html
-fsa-box:
-  languages:
-    en: interactives/fsa-box.html
-fsa-light:
-  languages:
-    en: interactives/fsa-light.html
-fsa-washing-machine:
-  languages:
-    en: interactives/fsa-washing-machine.html
-hex-background-colour:
-  languages:
-    en: interactives/hex-background-colour.html
-high-score-boxes:
-  languages:
-    en: interactives/high-score-boxes.html
-huffman-tree:
-  languages:
-    en: interactives/huffman-tree.html
-image-bit-comparer:
-  languages:
-    en: interactives/image-bit-comparer.html
-jpeg-compression:
-  languages:
-    en: interactives/jpeg-compression.html
-md5-hash:
-  languages:
-    en: interactives/md5-hash.html
-mips-assembler:
-  languages:
-    en: interactives/mips-assembler.html
-mips-simulator:
-  languages:
-    en: interactives/mips-simulator.html
-ncea-guide-selector:
-  languages:
-    en: interactives/ncea-guide-selector.html
-nfa-guesser:
-  languages:
-    en: interactives/nfa-guesser.html
-no-help:
-  languages:
-    en: interactives/no-help.html
-number-generator:
-  languages:
-    en: interactives/number-generator.html
-packet-attack:
-  languages:
-    en: interactives/packet-attack.html
-packet-attack-level-creator:
-  languages:
-    en: interactives/packet-attack-level-creator.html
-parity:
-  languages:
-    en: interactives/parity.html
-payment-interface:
-  languages:
-    en: interactives/payment-interface.html
-pixel-viewer:
-  languages:
-    en: interactives/pixel-viewer.html
-python-interpreter:
-  languages:
-    en: interactives/python-interpreter.html
-regular-expression-filter:
-  languages:
-    en: interactives/regular-expression-filter.html
-regular-expression-search:
-  languages:
-    en: interactives/regular-expression-search.html
-rgb-mixer:
-  languages:
-    en: interactives/rgb-mixer.html
-rsa-jsencrypt:
-  languages:
-    en: interactives/rsa-jsencrypt.html
-rsa-key-generator:
-  languages:
-    en: interactives/rsa-key-generator.html
-rsa-no-padding:
-  languages:
-    en: interactives/rsa-no-padding.html
-run-length-encoding:
-  languages:
-    en: interactives/run-length-encoding.html
-searching-algorithms:
-  languages:
-    en: interactives/searching-algorithms.html
-sha2:
-  languages:
-    en: interactives/sha2.html
-sorting-algorithm-comparison:
-  languages:
-    en: interactives/sorting-algorithm-comparison.html
-sorting-algorithms:
-  languages:
-    en: interactives/sorting-algorithms.html
-trainsylvania:
-  languages:
-    en: interactives/trainsylvania.html
-trainsylvania-planner:
-  languages:
-    en: interactives/trainsylvania-planner.html
-trig-function-calculator:
-  languages:
-    en: interactives/trig-function-calculator.html
-unicode-binary:
-  languages:
-    en: interactives/unicode-binary.html
-unicode-chars:
-  languages:
-    en: interactives/unicode-chars.html
-unicode-length:
-  languages:
-    en: interactives/unicode-length.html
-viola-jones-face-detector:
-  languages:
-    en: interactives/viola-jones-face-detector.html
+# base-calculator:
+#   languages:
+#     en: interactives/base-calculator.html
+# big-number-calculator:
+#   languages:
+#     en: interactives/big-number-calculator.html
+# bin-packing:
+#   languages:
+#     en: interactives/bin-packing.html
+# binary-cards:
+#   languages:
+#     en: interactives/binary-cards.html
+# box-rotation:
+#   languages:
+#     en: interactives/box-rotation.html
+# box-translation:
+#   languages:
+#     en: interactives/box-translation.html
+# caesar-cipher:
+#   languages:
+#     en: interactives/caesar-cipher.html
+# checksum-calculator:
+#   languages:
+#     en: interactives/checksum-calculator.html
+# checksum-calculator-gtin-13:
+#   languages:
+#     en: interactives/checksum-calculator-gtin-13.html
+# close-window:
+#   languages:
+#     en: interactives/close-window.html
+# cmy-mixer:
+#   languages:
+#     en: interactives/cmy-mixer.html
+# colour-matcher:
+#   languages:
+#     en: interactives/colour-matcher.html
+# compression-comparer:
+#   languages:
+#     en: interactives/compression-comparer.html
+# confused-buttons:
+#   languages:
+#     en: interactives/confused-buttons.html
+# date-picker:
+#   languages:
+#     en: interactives/date-picker.html
+# deceiver:
+#   languages:
+#     en: interactives/deceiver.html
+# delay-analyser:
+#   languages:
+#     en: interactives/delay-analyser.html
+# delayed-checkbox:
+#   languages:
+#     en: interactives/delayed-checkbox.html
+# frequency-analysis:
+#   languages:
+#     en: interactives/frequency-analysis.html
+# fsa-box:
+#   languages:
+#     en: interactives/fsa-box.html
+# fsa-light:
+#   languages:
+#     en: interactives/fsa-light.html
+# fsa-washing-machine:
+#   languages:
+#     en: interactives/fsa-washing-machine.html
+# hex-background-colour:
+#   languages:
+#     en: interactives/hex-background-colour.html
+# high-score-boxes:
+#   languages:
+#     en: interactives/high-score-boxes.html
+# huffman-tree:
+#   languages:
+#     en: interactives/huffman-tree.html
+# image-bit-comparer:
+#   languages:
+#     en: interactives/image-bit-comparer.html
+# jpeg-compression:
+#   languages:
+#     en: interactives/jpeg-compression.html
+# md5-hash:
+#   languages:
+#     en: interactives/md5-hash.html
+# mips-assembler:
+#   languages:
+#     en: interactives/mips-assembler.html
+# mips-simulator:
+#   languages:
+#     en: interactives/mips-simulator.html
+# ncea-guide-selector:
+#   languages:
+#     en: interactives/ncea-guide-selector.html
+# nfa-guesser:
+#   languages:
+#     en: interactives/nfa-guesser.html
+# no-help:
+#   languages:
+#     en: interactives/no-help.html
+# number-generator:
+#   languages:
+#     en: interactives/number-generator.html
+# packet-attack:
+#   languages:
+#     en: interactives/packet-attack.html
+# packet-attack-level-creator:
+#   languages:
+#     en: interactives/packet-attack-level-creator.html
+# parity:
+#   languages:
+#     en: interactives/parity.html
+# payment-interface:
+#   languages:
+#     en: interactives/payment-interface.html
+# pixel-viewer:
+#   languages:
+#     en: interactives/pixel-viewer.html
+# python-interpreter:
+#   languages:
+#     en: interactives/python-interpreter.html
+# regular-expression-filter:
+#   languages:
+#     en: interactives/regular-expression-filter.html
+# regular-expression-search:
+#   languages:
+#     en: interactives/regular-expression-search.html
+# rgb-mixer:
+#   languages:
+#     en: interactives/rgb-mixer.html
+# rsa-jsencrypt:
+#   languages:
+#     en: interactives/rsa-jsencrypt.html
+# rsa-key-generator:
+#   languages:
+#     en: interactives/rsa-key-generator.html
+# rsa-no-padding:
+#   languages:
+#     en: interactives/rsa-no-padding.html
+# run-length-encoding:
+#   languages:
+#     en: interactives/run-length-encoding.html
+# searching-algorithms:
+#   languages:
+#     en: interactives/searching-algorithms.html
+# sha2:
+#   languages:
+#     en: interactives/sha2.html
+# sorting-algorithm-comparison:
+#   languages:
+#     en: interactives/sorting-algorithm-comparison.html
+# sorting-algorithms:
+#   languages:
+#     en: interactives/sorting-algorithms.html
+# trainsylvania:
+#   languages:
+#     en: interactives/trainsylvania.html
+# trainsylvania-planner:
+#   languages:
+#     en: interactives/trainsylvania-planner.html
+# trig-function-calculator:
+#   languages:
+#     en: interactives/trig-function-calculator.html
+# unicode-binary:
+#   languages:
+#     en: interactives/unicode-binary.html
+# unicode-chars:
+#   languages:
+#     en: interactives/unicode-chars.html
+# unicode-length:
+#   languages:
+#     en: interactives/unicode-length.html
+# viola-jones-face-detector:
+#   languages:
+#     en: interactives/viola-jones-face-detector.html


### PR DESCRIPTION
This PR removes all content except the introduction chapter to allow us to methodically work through chapters and interactives to bring content up to standard with translations enabled.