### PR TITLE
Add blockquote in introduction

### DIFF
--- a/csfieldguide/chapters/content/en/introduction/introduction.md
+++ b/csfieldguide/chapters/content/en/introduction/introduction.md
@@ -40,9 +40,13 @@ If you are searching millions of items of data, or displaying millions of pixels
 
 Here's some advice from Fred Wilson, who has invested in many high profile tech companies:
 
-- First and foremost, we believe that speed is more than a feature. Speed is the most important feature. If your application is slow, people won't use it. I see this more with mainstream users than I do with power users. I think that power users sometimes have a bit of sympathetic eye to the challenges of building really fast web apps, and maybe they're willing to live with it, but when I look at my wife and kids, they're my mainstream view of the world. If something is slow, they're just gone. ... speed is more than a feature. It's a requirement.
+{blockquote source="http://triple-networks.com/2011/12/06/10-golden-principles-of-successful-web-apps/)" footer="true"}
 
-- [Fred Wilson](https://en.wikipedia.org/wiki/Fred_Wilson_(financier\)) ([Source](http://triple-networks.com/2011/12/06/10-golden-principles-of-successful-web-apps/))
+First and foremost, we believe that speed is more than a feature. Speed is the most important feature. If your application is slow, people won't use it. I see this more with mainstream users than I do with power users. I think that power users sometimes have a bit of sympathetic eye to the challenges of building really fast web apps, and maybe they're willing to live with it, but when I look at my wife and kids, they're my mainstream view of the world. If something is slow, they're just gone. ... speed is more than a feature. It's a requirement.
+
+- [Fred Wilson](https://en.wikipedia.org/wiki/Fred_Wilson_(financier))
+
+{blockquote end}
 
 A key theme in computer science is working out how to make things run fast, especially if you want to be able to sell your software to the large market of people using old-generation smartphones, or run it in a data centre where you pay by the minute for computing time.
 You can't just tell your customers to buy a faster device --- you need to deliver efficient software.

--- a/csfieldguide/chapters/content/en/introduction/introduction.md
+++ b/csfieldguide/chapters/content/en/introduction/introduction.md
@@ -40,7 +40,7 @@ If you are searching millions of items of data, or displaying millions of pixels
 
 Here's some advice from Fred Wilson, who has invested in many high profile tech companies:
 
-{blockquote source="http://triple-networks.com/2011/12/06/10-golden-principles-of-successful-web-apps/)" footer="true"}
+{blockquote source="http://triple-networks.com/2011/12/06/10-golden-principles-of-successful-web-apps/" footer="true"}
 
 First and foremost, we believe that speed is more than a feature. Speed is the most important feature. If your application is slow, people won't use it. I see this more with mainstream users than I do with power users. I think that power users sometimes have a bit of sympathetic eye to the challenges of building really fast web apps, and maybe they're willing to live with it, but when I look at my wife and kids, they're my mainstream view of the world. If something is slow, they're just gone. ... speed is more than a feature. It's a requirement.
 

--- a/csfieldguide/static/scss/website.scss
+++ b/csfieldguide/static/scss/website.scss
@@ -153,3 +153,9 @@ h1, h2, h3, h4, h5, h6, details {
 .figure {
   display: block !important;
 }
+
+blockquote {
+  padding: 1rem 1rem 1rem 1.5rem;
+  font-size: 1.1rem !important;
+  border-left: 5px solid $csfg;
+}

--- a/csfieldguide/utils/custom_converter_templates/blockquote.html
+++ b/csfieldguide/utils/custom_converter_templates/blockquote.html
@@ -1,0 +1,11 @@
+<blockquote class="blockquote text-muted{% if alignment == 'left' %} text-left{% elif alignment =='center' %} text-center{% elif alignment =='right' %} text-right{% endif %}"
+{%- if source %} cite="{{ source }}"{% endif %}>
+{% autoescape false -%}
+{{ content }}
+{%- endautoescape -%}
+{% if footer or source %}
+<footer class="blockquote-footer">
+{{ footer }} {% if source %}(<a href="{{ source }}">{{ '{% trans "Source" %}'}}</a>){% endif %}
+</footer>
+{% endif %}
+</blockquote>

--- a/csfieldguide/utils/render_html_with_load_tags.py
+++ b/csfieldguide/utils/render_html_with_load_tags.py
@@ -2,7 +2,7 @@
 
 from django import template
 
-LOAD_TAGS = "{% load static %}{% load render_interactive_in_page %}"
+LOAD_TAGS = "{% load static %}{% load i18n %}{% load render_interactive_in_page %}"
 
 
 def render_html_with_load_tags(html, context=None):


### PR DESCRIPTION
Uses Verto 0.9.0 to display blockquote with custom template.

**Issue to raise:** `trans` tags within custom converter templates are not added to `django.po` when `makemessages` are run.