### PR TITLE
Ensure JavaScript catalog is created when related commands are run

### DIFF
--- a/csfg
+++ b/csfg
@@ -94,7 +94,6 @@ cmd_update() {
   echo ""
   dev_updatedata
   dev_rebuild_index
-  dev_compilemessages
 
   echo ""
   dev_collect_static
@@ -107,9 +106,6 @@ defhelp update 'Run Django migrate and updatedata commands and build static file
 # Update and collect static files
 dev_update_static() {
   dev_static
-
-  echo ""
-  dev_compilemessages
 
   echo ""
   dev_collect_static
@@ -138,7 +134,6 @@ dev_compilemessages() {
   echo "Compiling message files..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py compilemessages
   docker-compose exec django /docker_venv/bin/python3 ./manage.py compilejsi18n
-  echo "Note: You will need to run the 'collect_static' command now to copy compiled JS files to the correct directory."
 }
 defhelp -dev compilemessages 'Run Django compilemessages command.'
 
@@ -192,6 +187,7 @@ defhelp -dev shell "Open shell to Django folder."
 dev_static() {
   echo "Building static files..."
   docker-compose exec nginx gulp build
+  dev_compilemessages
 }
 defhelp -dev static 'Build static files.'
 

--- a/csfg
+++ b/csfg
@@ -75,12 +75,6 @@ defhelp start 'Start development environment.'
 cmd_end() {
   echo "Stopping systems... (takes roughly 10 to 20 seconds)"
   docker-compose down
-  echo
-  echo "Deleting system volumes..."
-  volumes=($(docker volume ls -qf dangling=true ))
-  for volume in "${volumes[@]}"; do
-      docker volume rm "${volume}"
-  done
 }
 defhelp end 'Stop development environment.'
 
@@ -90,7 +84,7 @@ cmd_restart() {
 }
 defhelp restart 'Stop and then restart development environment.'
 
-# Run Django migrate and updatedata commands
+# Completely update system
 cmd_update() {
   dev_static
 
@@ -109,6 +103,20 @@ cmd_update() {
   echo "Open your preferred web browser to the URL 'localhost:81'"
 }
 defhelp update 'Run Django migrate and updatedata commands and build static files.'
+
+# Update and collect static files
+dev_update_static() {
+  dev_static
+
+  echo ""
+  dev_compilemessages
+
+  echo ""
+  dev_collect_static
+  echo ""
+  echo -e "\n${GREEN}Static files are updated!${NC}"
+}
+defhelp -dev update_static 'Update and collect static files.'
 
 # Build Docker images
 dev_build() {
@@ -254,14 +262,6 @@ defhelp -dev updatedata 'Run updatedata command.'
 cmd_clean() {
   echo "If the following commands return an argument not found error,"
   echo "this is because there is nothing to delete for clean up."
-
-  echo
-  echo "Deleting unused volumes..."
-
-  unused_volumes=($(docker volume ls -qf dangling=true))
-  for vol in "${unused_volumes[@]}"; do
-      docker volume rm "${vol}"
-  done
 
   echo
   echo "Deleting exited containers..."


### PR DESCRIPTION
This pull request changes the following in the `csfg` helper script:

- Compiles messages within the `static` command as compiling JavaScript translations creates a static file. It was created in the `update` command but this changes give a more expected behaviour.
- Add new command for updating and collecting static files: `dev update_static`
- Remove deletion of volumes as this deletes a Docker volume creating for storing node modules. Tidying Docker should be a user choice/action, not a project action.

Fixes #730