### PR TITLE
Add off-by-one interactive to replace image in HCI chapter

### DIFF
--- a/csfieldguide/chapters/content/en/human-computer-interaction/sections/interface-usability.md
+++ b/csfieldguide/chapters/content/en/human-computer-interaction/sections/interface-usability.md
@@ -152,7 +152,7 @@ A similar issue occurs on keyboards; for example, control-W might close just one
 Of course, this can be fixed by either checking if the user quits, or by having all the windows saved so that the user just needs to open the browser again to get their work back.
 This can also occur in web forms, where there is a reset button next to the submit button, and the off-by-one error causes the user to lose all the data they just entered.
 
-{image file-path="img/chapters/reset-submit.png" alt="A risky interface."}
+{interactive slug="off-by-one" type="in-page"}
 
 ## Deliberately making tasks more challenging
 

--- a/csfieldguide/interactives/content/en/interactives.yaml
+++ b/csfieldguide/interactives/content/en/interactives.yaml
@@ -74,6 +74,8 @@ no-help:
   name: No Help
 number-generator:
   name: Number Generator
+off-by-one:
+  name: Off By One
 packet-attack:
   name: packet-attack (broken)
 packet-attack-level-creator:

--- a/csfieldguide/interactives/content/structure/interactives.yaml
+++ b/csfieldguide/interactives/content/structure/interactives.yaml
@@ -112,6 +112,9 @@ awful-calculator:
 # number-generator:
 #   languages:
 #     en: interactives/number-generator.html
+# off-by-one:
+#   languages:
+#     en: interactives/off-by-one.html
 # packet-attack:
 #   languages:
 #     en: interactives/packet-attack.html

--- a/csfieldguide/templates/interactives/off-by-one.html
+++ b/csfieldguide/templates/interactives/off-by-one.html
@@ -1,0 +1,11 @@
+{% extends interactive_mode_template %}
+
+{% load i18n %}
+{% load static %}
+
+{% block html %}
+  <div class="d-flex justify-content-center">
+    <button class="btn btn-primary m-1">{% trans "Clear form" %}</button>
+    <button class="btn btn-primary m-1">{% trans "Submit now" %}</button>
+  </div>
+{% endblock html %}


### PR DESCRIPTION
Replace 
![image](https://user-images.githubusercontent.com/16066822/46052644-6e51ad80-c193-11e8-839c-f918c6b61fa9.png)

with
![image](https://user-images.githubusercontent.com/16066822/46052698-9e994c00-c193-11e8-9c3e-6635f544423a.png)

So that the words can be translated. Relates to #732 