### PR TITLE
Add unexpected-error interactive to replace image in HCI chapter

### DIFF
--- a/csfieldguide/chapters/content/en/human-computer-interaction/sections/usability-heuristics.md
+++ b/csfieldguide/chapters/content/en/human-computer-interaction/sections/usability-heuristics.md
@@ -306,7 +306,7 @@ There is some extra information not shown below such as "Path: Unknown" and "Err
 Searching for the error code can lead to suggested solutions, but it also leads to scam software that claims to fix the problem.
 By not giving useful error recovery information, the system has put the user at the mercy of the advice available online!
 
-{image file-path="img/chapters/error-vague.png" alt="Vague error message: An unexpected error has occurred."}
+{interactive slug="unexpected-error" type="in-page"}
 
 A variant of unhelpful error messages is one that gives two alternatives, such as "File may not exist, or it may already be in use".
 A better message would save the user having to figure out which of these is the problem.

--- a/csfieldguide/interactives/content/en/interactives.yaml
+++ b/csfieldguide/interactives/content/en/interactives.yaml
@@ -116,6 +116,8 @@ trainsylvania-planner:
   name: Trainsylvania Planner
 trig-function-calculator:
   name: Trig Function Calculator
+unexpected-error:
+  name: Unexpected Error
 unicode-binary:
   name: unicode-binary (broken)
 unicode-chars:

--- a/csfieldguide/interactives/content/structure/interactives.yaml
+++ b/csfieldguide/interactives/content/structure/interactives.yaml
@@ -175,6 +175,9 @@ awful-calculator:
 # trig-function-calculator:
 #   languages:
 #     en: interactives/trig-function-calculator.html
+# unexpected-error:
+#   languages:
+#     en: interactives/unexpected-error.html
 # unicode-binary:
 #   languages:
 #     en: interactives/unicode-binary.html

--- a/csfieldguide/templates/interactives/unexpected-error.html
+++ b/csfieldguide/templates/interactives/unexpected-error.html
@@ -1,0 +1,20 @@
+{% extends interactive_mode_template %}
+
+{% load i18n %}
+{% load static %}
+
+{% block html %}
+	<div class="container">
+		<div class="row justify-content-center">
+		  <div class="card">
+		  	<div class="card-header text-left">
+		  		{% trans "Audio Player" %}
+		  	</div>
+		  	<div class="card-body text-left">
+			    <p class="card-text text-primary">{% trans "An error occurred while troubleshooting:" %}</p>
+			    <p class="card-text"><small>{% trans "An unexpected error has occurred. The troubleshooting wizard can't continue." %}</small></p>
+			  </div>
+		  </div>
+		</div>
+	</div>
+{% endblock html %}


### PR DESCRIPTION
Replace
![image](https://user-images.githubusercontent.com/16066822/46180326-de873d00-c313-11e8-9a1d-599d931ff002.png)

with
![image](https://user-images.githubusercontent.com/16066822/46180347-f65ec100-c313-11e8-85c5-79a412c8b806.png)

So that the words can be translated. Relates to #732