### PR TITLE
 Fix bug where section numbers weren't correct

### DIFF
--- a/csfieldguide/chapters/content/en/algorithms/algorithms.md
+++ b/csfieldguide/chapters/content/en/algorithms/algorithms.md
@@ -2,8 +2,6 @@
 
 {comment explain different views of algorithm (programming context) and Algorithm (that have interesting complexity); use https://www.youtube.com/watch?v=6hfOvs8pY1k for the former?}
 
-# What's the big picture?
-
 Every computer device you have ever used, from your school computers to your calculator, has been using algorithms to tell it how to do whatever it was doing.
 Algorithms are a very important topic in Computer Science because they help software developers create efficient and error free programs.
 The most important thing to remember about algorithms is that there can be many different algorithms for the same problem, but some are much better than others!

--- a/csfieldguide/chapters/content/en/artificial-intelligence/artificial-intelligence.md
+++ b/csfieldguide/chapters/content/en/artificial-intelligence/artificial-intelligence.md
@@ -1,7 +1,5 @@
 # Artificial Intelligence
 
-# What's the big picture?
-
 Artificial Intelligence conjures up all sorts of images — perhaps you think of friendly systems that can talk to you and solve tough problems; or maniac robots that are bent on world domination?
 There's the promise of driverless cars that are safer than human drivers, and the worry of  medical advice systems that hold people's lives in their virtual hands.
 The field of Artificial Intelligence is a part of computer science that has a lot of promise and also raises a lot of concerns.

--- a/csfieldguide/chapters/content/en/coding-compression/coding-compression.md
+++ b/csfieldguide/chapters/content/en/coding-compression/coding-compression.md
@@ -1,7 +1,5 @@
 # Coding - Compression
 
-# What's the big picture?
-
 Data compression reduces the amount of space needed to store files.
 If you can halve the size of a file, you can store twice as many files for the same cost, or you can download the files twice as fast (and at half the cost if you're paying for the download).
 Even though disks are getting bigger and high bandwidth is becoming common, it's nice to get even more value by working with smaller, compressed files.

--- a/csfieldguide/chapters/content/en/coding-encryption/coding-encryption.md
+++ b/csfieldguide/chapters/content/en/coding-encryption/coding-encryption.md
@@ -1,7 +1,5 @@
 # Coding - Encryption
 
-# What's the big picture?
-
 Encryption is used to keep data secret.
 In its simplest form, a file or data transmission is garbled so that only authorised people with a secret "key" can unlock the original text.
 If you're using digital devices then you'll be using systems based on encryption all the time: when you use online banking, when you access data through wifi, when you pay for something with a credit card (either by swiping, inserting or tapping), in fact, nearly every activity will involve layers of encryption.

--- a/csfieldguide/chapters/content/en/coding-error-control/coding-error-control.md
+++ b/csfieldguide/chapters/content/en/coding-error-control/coding-error-control.md
@@ -1,7 +1,5 @@
 # Coding - Error Control
 
-# What's the big picture?
-
 {panel type="teacher-note"}
 
 # Using the parity trick in a classroom

--- a/csfieldguide/chapters/content/en/coding-introduction/coding-introduction.md
+++ b/csfieldguide/chapters/content/en/coding-introduction/coding-introduction.md
@@ -1,7 +1,5 @@
 # Coding - Introduction
 
-# What's the big picture?
-
 The word "code" has lots of meanings in computer science.
 It's often used to talk about programming, and a program can be referred to as "source code".
 Even binary representation of information is sometimes referred to as a code.

--- a/csfieldguide/chapters/content/en/complexity-and-tractability/complexity-and-tractability.md
+++ b/csfieldguide/chapters/content/en/complexity-and-tractability/complexity-and-tractability.md
@@ -10,8 +10,6 @@ The video [The Power of Exponentials, Big and Small](http://blossoms.mit.edu/vid
 
 {panel end}
 
-# What's the big picture?
-
 {comment consider using this somewhere: David Harel earlier in the year about algorithms, and he made the point that getting students to plot running times on a log-log graph can be useful because polynomial time algorithms form a straight line, but exponential don't.}
 
 Are there problems that are too hard even for computers?

--- a/csfieldguide/chapters/content/en/computer-graphics/computer-graphics.md
+++ b/csfieldguide/chapters/content/en/computer-graphics/computer-graphics.md
@@ -1,7 +1,5 @@
 # Computer Graphics
 
-# What's the big picture?
-
 Computer graphics will be familiar from games, films and images, and there is amazing software available to create images, but how does the software work?
 The role of a computer scientist is not just to *use* graphics systems, but to *create* them, and especially invent new techniques.
 

--- a/csfieldguide/chapters/content/en/computer-vision/computer-vision.md
+++ b/csfieldguide/chapters/content/en/computer-vision/computer-vision.md
@@ -1,7 +1,5 @@
 # Computer Vision
 
-# What's the big picture?
-
 When computers were first developed, the only way they could interact with the outside world was through the input that people wired or typed into them.
 Digital devices today often have cameras, microphones and other sensors through which programs can perceive the world we live in automatically.
 Processing images from a camera, and looking for interesting information in them, is what we call *computer vision*.

--- a/csfieldguide/chapters/content/en/data-representation/data-representation.md
+++ b/csfieldguide/chapters/content/en/data-representation/data-representation.md
@@ -9,8 +9,6 @@ If students struggle to do this by hand, a lot can be done using spreadsheets.
 
 {panel end}
 
-# What's the big picture?
-
 Computers are machines that do stuff with information.
 They let you view, listen, create, and edit information in documents, images, videos, sound, spreadsheets and databases.
 They let you play games in simulated worlds that don’t really exist except as information inside the computer’s memory and displayed on the screen.

--- a/csfieldguide/chapters/content/en/formal-languages/formal-languages.md
+++ b/csfieldguide/chapters/content/en/formal-languages/formal-languages.md
@@ -1,7 +1,5 @@
 # Formal Languages
 
-# What's the big picture?
-
 If you've ever written a text-based program or typed a formula in a spreadsheet,
 chances are that at some stage the system has told you there's an error and won't even attempt to follow your instructions.
 

--- a/csfieldguide/chapters/content/en/human-computer-interaction/human-computer-interaction.md
+++ b/csfieldguide/chapters/content/en/human-computer-interaction/human-computer-interaction.md
@@ -1,7 +1,5 @@
 # Human Computer Interaction
 
-# What's the big picture?
-
 {panel type="teacher-note"}
 
 # The scope of user interfaces

--- a/csfieldguide/chapters/content/en/introduction/introduction.md
+++ b/csfieldguide/chapters/content/en/introduction/introduction.md
@@ -12,8 +12,6 @@ The best way to provide feedback is through the "Feedback" link at the bottom of
 
 {panel end}
 
-# What's the big picture?
-
 Why is it that people have a love-hate relationship with computers?
 Why are some people so fanatical about particular types of computers, while others have been so angry at digital devices that they have been physically violent with them?
 And what does this have to do with computer science?

--- a/csfieldguide/chapters/content/en/network-communication-protocols/network-communication-protocols.md
+++ b/csfieldguide/chapters/content/en/network-communication-protocols/network-communication-protocols.md
@@ -1,7 +1,5 @@
 # Network Communication Protocols
 
-# What's the big picture?
-
 Think about the last time someone sent you mail via the post.
 They probably wrote some content on some paper, put it in an envelope, wrote an address and put it in a postbox.
 From there, the letter probably went into a sorting center, got sorted, and was put in a bag.

--- a/csfieldguide/chapters/content/en/programming-languages/programming-languages.md
+++ b/csfieldguide/chapters/content/en/programming-languages/programming-languages.md
@@ -1,7 +1,5 @@
 # Programming Languages
 
-# What's the big picture?
-
 Programming, sometimes referred to as coding, is a nuts and bolts activity for computer science.
 While this book won't teach you how to program (we've given some links to sites that can do this in the introduction), we are going to look at what a programming language is, and how computer scientists breath life into a language.
 From a programmer's point of view, they type some instructions, and the computer follows them.

--- a/csfieldguide/chapters/content/en/software-engineering/software-engineering.md
+++ b/csfieldguide/chapters/content/en/software-engineering/software-engineering.md
@@ -14,8 +14,6 @@ In this chapter we've tried to capture what really happens in industry, and sugg
 
 {panel end}
 
-# What's the big picture?
-
 Software failures happen all the time.
 Sometimes it’s a little bug that makes a program difficult to use; other times an error might crash your entire computer.
 Some software failures are more spectacular than others.

--- a/csfieldguide/chapters/management/commands/_ChapterSectionsLoader.py
+++ b/csfieldguide/chapters/management/commands/_ChapterSectionsLoader.py
@@ -11,6 +11,8 @@ from utils.check_required_files import check_interactives
 class ChapterSectionsLoader(TranslatableModelLoader):
     """Custom loader for loading chapter sections."""
 
+    extra_converter_templates_directory = "chapter-section"
+
     def __init__(self, factory, chapter, **kwargs):
         """Create the loader for loading chapter sections.
 

--- a/csfieldguide/chapters/management/commands/_ChaptersLoader.py
+++ b/csfieldguide/chapters/management/commands/_ChaptersLoader.py
@@ -12,6 +12,8 @@ from chapters.models import Chapter
 class ChaptersLoader(TranslatableModelLoader):
     """Custom loader for loading chapters."""
 
+    extra_converter_templates_directory = "chapter"
+
     def __init__(self, factory, chapter_number, **kwargs):
         """Create the loader for loading a Chapter.
 

--- a/csfieldguide/templates/chapters/chapter.html
+++ b/csfieldguide/templates/chapters/chapter.html
@@ -8,7 +8,7 @@
 {% endblock title %}
 
 {% block page_heading %}
-  {{ chapter.name }}
+  <span class="text-white-50">{{ chapter.number }}.</span> {{ chapter.name }}
 {% endblock page_heading %}
 
 {% block content %}

--- a/csfieldguide/templates/chapters/chapter_section.html
+++ b/csfieldguide/templates/chapters/chapter_section.html
@@ -8,7 +8,13 @@
 {% endblock title %}
 
 {% block page_heading %}
-<small>{{ chapter_section.chapter.name }}</small><br>{{ chapter_section.name }}
+  <small>
+    <a href="{% url 'chapters:chapter' chapter.slug %}" class="text-white-50">
+      {{ chapter_section.chapter.name }}
+    </a>
+  </small>
+  <br>
+  <span class="text-white-50">{{ chapter.number }}.{{ chapter_section.number }}.</span> {{ chapter_section.name }}
 {% endblock page_heading %}
 
 {% block left_column_content %}

--- a/csfieldguide/utils/BaseLoader.py
+++ b/csfieldguide/utils/BaseLoader.py
@@ -199,11 +199,25 @@ class BaseLoader():
         """
         templates = dict()
         template_path = settings.CUSTOM_VERTO_TEMPLATES
+        templates.update(self.read_template_files(template_path))
+        if hasattr(self, "extra_converter_templates_directory"):
+            directory = self.extra_converter_templates_directory
+            template_path = os.path.join(template_path, directory)
+            templates.update(self.read_template_files(template_path))
+        return templates
+
+    def read_template_files(self, template_path):
+        """Read custom HTML templates from specified path.
+
+        Returns:
+            templates: dictionary of html templates
+        """
+        templates = dict()
         for file in listdir(template_path):
             template_file = re.search(r"(.*?).html$", file)
             if template_file:
                 template_name = template_file.groups()[0]
-                templates[template_name] = open(template_path + file).read()
+                templates[template_name] = open(os.path.join(template_path, file)).read()
         return templates
 
     @abc.abstractmethod

--- a/csfieldguide/utils/custom_converter_templates/chapter-section/heading.html
+++ b/csfieldguide/utils/custom_converter_templates/chapter-section/heading.html
@@ -1,0 +1,22 @@
+<{{ heading_type }} id="{{ title_slug }}">
+<span class="section_number">
+{{ "{{ chapter.number }}.{{ chapter_section.number }}" }}
+{%- if heading_level >= 2 -%}
+.{{ level_2 }}
+{%- endif -%}
+{%- if heading_level >= 3 -%}
+.{{ level_3 }}
+{%- endif -%}
+{%- if heading_level >= 4 -%}
+.{{ level_4 }}
+{%- endif -%}
+{%- if heading_level >= 5 -%}
+.{{ level_5 }}
+{%- endif -%}
+{%- if heading_level >= 6 -%}
+.{{ level_6 }}
+{%- endif -%}
+.
+</span>
+{{ title }}
+</{{ heading_type }}>

--- a/csfieldguide/utils/custom_converter_templates/chapter/heading.html
+++ b/csfieldguide/utils/custom_converter_templates/chapter/heading.html
@@ -1,0 +1,22 @@
+<{{ heading_type }} id="{{ title_slug }}">
+<span class="section_number">
+{{ "{{ chapter.number }}" }}.0
+{%- if heading_level >= 2 -%}
+.{{ level_2 }}
+{%- endif -%}
+{%- if heading_level >= 3 -%}
+.{{ level_3 }}
+{%- endif -%}
+{%- if heading_level >= 4 -%}
+.{{ level_4 }}
+{%- endif -%}
+{%- if heading_level >= 5 -%}
+.{{ level_5 }}
+{%- endif -%}
+{%- if heading_level >= 6 -%}
+.{{ level_6 }}
+{%- endif -%}
+.
+</span>
+{{ title }}
+</{{ heading_type }}>


### PR DESCRIPTION
Uses custom templates depending on depth of document.

Also removes "What's the big picture?" heading from all chapters, and adds link to chapter from chapter section in page header.

Fixes #703 