### PR TITLE
Add binary-mode-calculator interactive to replace image in HCI chapter

### DIFF
--- a/csfieldguide/chapters/content/en/human-computer-interaction/sections/usability-heuristics.md
+++ b/csfieldguide/chapters/content/en/human-computer-interaction/sections/usability-heuristics.md
@@ -212,7 +212,7 @@ And here's another example, this time with a computer science slant: the followi
 The trouble is that in this mode you can still type in decimal digits, which gives an error when you do the calculation.
 A user could easily not notice that it's in binary mode, and the error message isn't particularly helpful!
 
-{image file-path="img/chapters/binary-calculator-screenshot.png" alt="A calculator in binary mode that still allows you to type in digits other than 0 and 1, but complains later."}
+{interactive slug="binary-mode-calculator" type="in-page"}
 
 ## Recognition rather than recall
 

--- a/csfieldguide/interactives/content/en/interactives.yaml
+++ b/csfieldguide/interactives/content/en/interactives.yaml
@@ -16,6 +16,8 @@ bin-packing:
   name: bin-packing (broken)
 binary-cards:
   name: Binary Cards
+binary-mode-calculator:
+  name: Binary Mode Calculator
 box-rotation:
   name: box-rotation (broken)
 box-translation:

--- a/csfieldguide/interactives/content/structure/interactives.yaml
+++ b/csfieldguide/interactives/content/structure/interactives.yaml
@@ -25,6 +25,9 @@ awful-calculator:
 # binary-cards:
 #   languages:
 #     en: interactives/binary-cards.html
+binary-mode-calculator:
+  languages:
+    en: interactives/binary-mode-calculator.html
 # box-rotation:
 #   languages:
 #     en: interactives/box-rotation.html

--- a/csfieldguide/static/interactives/binary-mode-calculator/scss/binary-mode-calculator.scss
+++ b/csfieldguide/static/interactives/binary-mode-calculator/scss/binary-mode-calculator.scss
@@ -3,7 +3,7 @@
     border: 2px solid #D0D0D0;
     border-radius: 2px;
     margin-top: 1rem;
-    padding: 0.6rem !important;
+    padding: 0.1rem 0.6rem 0.6rem 0.6rem !important;
     margin: 0.3rem;
   }
   button {
@@ -19,8 +19,11 @@
     background-color: #EFEFEF;
     color: #000;
     text-align: right;
-    font-size: 1rem;
+    font-size: 1.2rem;
     border: 1px solid #D0D0D0;
     border-radius: 2px;
+  }
+  .mode-dropdown {
+    background-color: #EFEFEF;
   }
 }

--- a/csfieldguide/static/interactives/binary-mode-calculator/scss/binary-mode-calculator.scss
+++ b/csfieldguide/static/interactives/binary-mode-calculator/scss/binary-mode-calculator.scss
@@ -1,0 +1,26 @@
+#binary-mode-calculator {
+  .calculator {
+    border: 2px solid #D0D0D0;
+    border-radius: 2px;
+    margin-top: 1rem;
+    padding: 0.6rem !important;
+    margin: 0.3rem;
+  }
+  button {
+    width: 100%;
+    padding: 0;
+    margin: 2px;
+    color: white;
+  }
+  .calculator-input {
+    margin: 0;
+    padding: 0 0.3rem;
+    width: 100%;
+    background-color: #EFEFEF;
+    color: #000;
+    text-align: right;
+    font-size: 1rem;
+    border: 1px solid #D0D0D0;
+    border-radius: 2px;
+  }
+}

--- a/csfieldguide/templates/interactives/binary-mode-calculator.html
+++ b/csfieldguide/templates/interactives/binary-mode-calculator.html
@@ -5,8 +5,11 @@
 
 {% block html %}
   <div class="row justify-content-center" id="binary-mode-calculator">
-    <div class="col col-12 col-md-5 calculator">
-      <button class="btn btn-primary btn-sm dropdown-toggle" type="button">{% trans "Binary" %}</button>
+    <div class="col col-12 col-md-5 calculator pt-1">
+      <div class="text-left font-weight-bold small mb-2">
+        {% trans "Calculator" %}
+      </div>
+
       <div class="d-flex">
         <div class="calculator-input">168 &divide; 5</div>
       </div>
@@ -16,6 +19,17 @@
           {% trans "Malformed expression" %}
         </small>
       </div>
+
+      <form>
+        <div class="form-group row mb-1">
+          <label for="caluclator-mode" class="col-sm-2 col-form-label col-form-label-sm">{% trans "Mode: " %}</label>
+          <div class="col-sm-10">
+            <select class="form-control form-control-sm mode-dropdown">
+              <option selected>{% trans "Binary" %}</option>
+            </select>
+          </div>
+        </div>
+      </form>
 
       <div class="d-flex">
         <button type="button" class="btn btn-primary">7</button>

--- a/csfieldguide/templates/interactives/binary-mode-calculator.html
+++ b/csfieldguide/templates/interactives/binary-mode-calculator.html
@@ -1,0 +1,53 @@
+{% extends interactive_mode_template %}
+
+{% load i18n %}
+{% load static %}
+
+{% block html %}
+  <div class="row justify-content-center" id="binary-mode-calculator">
+    <div class="col col-12 col-md-5 calculator">
+      <button class="btn btn-primary btn-sm dropdown-toggle" type="button">{% trans "Binary" %}</button>
+      <div class="d-flex">
+        <div class="calculator-input">168 &divide; 5</div>
+      </div>
+
+      <div class="text-right">
+        <small>
+          {% trans "Malformed expression" %}
+        </small>
+      </div>
+
+      <div class="d-flex">
+        <button type="button" class="btn btn-primary">7</button>
+        <button type="button" class="btn btn-primary">8</button>
+        <button type="button" class="btn btn-primary">9</button>
+        <button type="button" class="btn btn-primary">&divide;</button>
+      </div>
+
+      <div class="d-flex">
+        <button type="button" class="btn btn-primary">4</button>
+        <button type="button" class="btn btn-primary">5</button>
+        <button type="button" class="btn btn-primary">6</button>
+        <button type="button" class="btn btn-primary">&times;</button>
+      </div>
+
+      <div class="d-flex">
+        <button type="button" class="btn btn-primary">1</button>
+        <button type="button" class="btn btn-primary">2</button>
+        <button type="button" class="btn btn-primary">3</button>
+        <button type="button" class="btn btn-primary">+</button>
+      </div>
+
+      <div class="d-flex">
+        <button type="button" class="btn btn-primary">.</button>
+        <button type="button" class="btn btn-primary">0</button>
+        <button type="button" class="btn btn-primary">=</button>
+        <button type="button" class="btn btn-primary">-</button>
+      </div>
+    </div>
+  </div>
+{% endblock html %}
+
+{% block css %}
+  <link rel="stylesheet" href="{% static 'interactives/binary-mode-calculator/css/binary-mode-calculator.css' %}">
+{% endblock css %}


### PR DESCRIPTION
Replace
![image](https://user-images.githubusercontent.com/16066822/46264898-11cd0480-c57e-11e8-9caa-b704332a1723.png)

with
![image](https://user-images.githubusercontent.com/16066822/46265606-80ad5c00-c584-11e8-9c2a-a130b19b3b2f.png)

So that the words can be translated. Relates to #732