### PR TITLE
Fix compilation of production JavaScript

### DIFF
--- a/csfieldguide/gulpfile.js
+++ b/csfieldguide/gulpfile.js
@@ -38,7 +38,7 @@ const autoprefixer = require('autoprefixer');
 // js
 const tap = require('gulp-tap');
 const babel = require('gulp-babel');
-const uglify = require('gulp-uglify');
+const terser = require('gulp-terser');
 const browserify = require('browserify');
 const jshint = require('gulp-jshint');
 const stylish = require('jshint-stylish');
@@ -180,7 +180,7 @@ var tasks = {
       .pipe(errorHandler(catchError))
       .pipe(gulpif(production, sourcemaps.init({loadMaps: true})))
       .pipe(gulpif(production, babel({ presets: ['env'] })))
-      .pipe(gulpif(production, uglify({keep_fnames: true})))
+      .pipe(gulpif(production, terser({keep_fnames: true})))
       .pipe(gulpif(production, sourcemaps.write('./')))
       .pipe(f.restore)
       .pipe(gulp.dest('build'));

--- a/csfieldguide/gulpfile.js
+++ b/csfieldguide/gulpfile.js
@@ -179,7 +179,6 @@ var tasks = {
       .pipe(buffer())
       .pipe(errorHandler(catchError))
       .pipe(gulpif(production, sourcemaps.init({loadMaps: true})))
-      .pipe(gulpif(production, babel({ presets: ['env'] })))
       .pipe(gulpif(production, terser({keep_fnames: true})))
       .pipe(gulpif(production, sourcemaps.write('./')))
       .pipe(f.restore)

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -46,7 +46,7 @@
     "gulp-sass": "4.0.1",
     "gulp-sourcemaps": "2.6.4",
     "gulp-tap": "1.0.1",
-    "gulp-uglify": "3.0.0",
+    "gulp-terser": "1.1.5",
     "gulp-util": "3.0.8",
     "jshint": "2.9.5",
     "jshint-stylish": "2.2.1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,11 +28,9 @@ services:
       dockerfile: ./infrastructure/nginx/Dockerfile
     volumes:
       - ./csfieldguide/:/app/
-      - node_modules:/app/node_modules
+      - /app/node_modules
     depends_on:
       - django
     ports:
       - "81:80"
 
-volumes:
-  node_modules:


### PR DESCRIPTION
Remove usage of babel and use terser package. This results in less complicated JavaScript (though our JavaScript should have good compatibility already) and a smaller file size (only 2kb smaller).

Fixes #750 
Once this pull request has been merged, a new issue should be raise to check browser compatibility.