### PR TITLE
Consistent numbering for chapter sections

### DIFF
--- a/csfieldguide/chapters/management/commands/_ChapterSectionsLoader.py
+++ b/csfieldguide/chapters/management/commands/_ChapterSectionsLoader.py
@@ -33,6 +33,7 @@ class ChapterSectionsLoader(TranslatableModelLoader):
                 field.
         """
         chapter_sections_structure = self.load_yaml_file(self.structure_file_path)
+        section_numbers = []
 
         for (section_slug, section_structure) in chapter_sections_structure.items():
 
@@ -56,6 +57,8 @@ class ChapterSectionsLoader(TranslatableModelLoader):
                     "section-number - value '{}' is invalid".format(section_number),
                     "section-number must be an integer value."
                 )
+
+            section_numbers.append(section_number)
 
             chapter_section_translations = self.get_blank_translation_dictionary()
 
@@ -83,3 +86,12 @@ class ChapterSectionsLoader(TranslatableModelLoader):
                 self.structure_file_path,
                 self.chapter,
             )
+
+        # assumes first section number is always 1
+        for counter, section_number in enumerate(section_numbers, 1):
+            if section_number != counter:
+                raise InvalidYAMLValueError(
+                    self.structure_file_path,
+                    "section-number - value '{}' is invalid".format(section_number),
+                    "section-numbers must be in sequential order. The next expected number was '{}'.".format(counter)
+                )

--- a/csfieldguide/templates/chapters/chapter.html
+++ b/csfieldguide/templates/chapters/chapter.html
@@ -30,6 +30,9 @@
         <a href="{% url 'chapters:chapter_section' chapter.slug section.slug %}">
           {{ section.name }}
         </a>
+        {% if not chapter_section.translation_available %}
+          {% include "generic/not-available-badge.html" %}
+        {% endif %}
       </li>
     {% endfor %}
   </ol>

--- a/csfieldguide/templates/chapters/chapter.html
+++ b/csfieldguide/templates/chapters/chapter.html
@@ -12,29 +12,37 @@
 {% endblock page_heading %}
 
 {% block content %}
-  {% if chapter.video %}
-    <div class="row mb-3">
-      <div class="col-sm-12 col-md-10 offset-md-1 text-center">
-        <div class="embed-responsive embed-responsive-16by9">
-          <iframe src="{{ chapter.video }}" class="embed-responsive-item" frameborder="0" allowfullscreen></iframe>
+  {% if chapter.translation_available %}
+    {% if chapter.video %}
+      <div class="row mb-3">
+        <div class="col-sm-12 col-md-10 offset-md-1 text-center">
+          <div class="embed-responsive embed-responsive-16by9">
+            <iframe src="{{ chapter.video }}" class="embed-responsive-item" frameborder="0" allowfullscreen></iframe>
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
+    {% render_html_field chapter.introduction %}
+  {% else %}
+    {% with model=chapter %}
+      {% include "generic/not-available-warning.html" %}
+    {% endwith %}
   {% endif %}
-  {% render_html_field chapter.introduction %}
 
   <h2>Sections in this chapter:</h2>
-  <ol>
+  <ul class="list-unstyled">
     {% for section in chapter_sections %}
       <li>
-        <a href="{% url 'chapters:chapter_section' chapter.slug section.slug %}">
+        {{ chapter.number }}.{{ section.number }}
+        <a href="{% url 'chapters:chapter_section' chapter.slug section.slug %}" class="ml-1{% if not section.translation_available %} text-muted{% endif %}">
           {{ section.name }}
         </a>
-        {% if not chapter_section.translation_available %}
+        {% if not section.translation_available %}
           {% include "generic/not-available-badge.html" %}
         {% endif %}
       </li>
     {% endfor %}
-  </ol>
+  </ul>
+
 
 {% endblock content %}

--- a/csfieldguide/templates/chapters/chapter.html
+++ b/csfieldguide/templates/chapters/chapter.html
@@ -33,7 +33,7 @@
   <ul class="list-unstyled">
     {% for section in chapter_sections %}
       <li>
-        {{ chapter.number }}.{{ section.number }}
+        {{ chapter.number }}.{{ section.number }}.
         <a href="{% url 'chapters:chapter_section' chapter.slug section.slug %}" class="ml-1{% if not section.translation_available %} text-muted{% endif %}">
           {{ section.name }}
         </a>

--- a/csfieldguide/templates/chapters/chapter_section.html
+++ b/csfieldguide/templates/chapters/chapter_section.html
@@ -18,16 +18,22 @@
 {% endblock page_heading %}
 
 {% block left_column_content %}
-  {% render_html_field chapter_section.content %}
+  {% if chapter_section.translation_available %}
+    {% render_html_field chapter_section.content %}
+  {% else %}
+    {% with model=chapter_section %}
+      {% include "generic/not-available-warning.html" %}
+    {% endwith %}
+  {% endif %}
 
   <div>
     {% if previous_section %}
-      <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn left">
+      <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn left {% if not chapter_section.translation_available %} text-muted{% endif %}">
         Previous: {{ previous_section.0.name }}
       </a>
     {% endif %}
     {% if next_section %}
-      <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn right">
+      <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn right {% if not chapter_section.translation_available %} text-muted{% endif %}">
         Next: {{ next_section.0.name }}
       </a>
     {% endif %}

--- a/csfieldguide/tests/chapters/loaders/assets/chapter-sections/en/non-sequential-section-numbers/non-sequential-section-numbers-section-1.md
+++ b/csfieldguide/tests/chapters/loaders/assets/chapter-sections/en/non-sequential-section-numbers/non-sequential-section-numbers-section-1.md
@@ -1,0 +1,3 @@
+# This is the first section
+
+This is the content for the first section.

--- a/csfieldguide/tests/chapters/loaders/assets/chapter-sections/en/non-sequential-section-numbers/non-sequential-section-numbers-section-2.md
+++ b/csfieldguide/tests/chapters/loaders/assets/chapter-sections/en/non-sequential-section-numbers/non-sequential-section-numbers-section-2.md
@@ -1,0 +1,3 @@
+# This is the second section
+
+This is the content for the second section.

--- a/csfieldguide/tests/chapters/loaders/assets/chapter-sections/en/non-sequential-section-numbers/non-sequential-section-numbers-section-4.md
+++ b/csfieldguide/tests/chapters/loaders/assets/chapter-sections/en/non-sequential-section-numbers/non-sequential-section-numbers-section-4.md
@@ -1,0 +1,3 @@
+# This is the fourth section
+
+This is the content for the fourth section.

--- a/csfieldguide/tests/chapters/loaders/assets/chapter-sections/structure/non-sequential-section-numbers/non-sequential-section-numbers.yaml
+++ b/csfieldguide/tests/chapters/loaders/assets/chapter-sections/structure/non-sequential-section-numbers/non-sequential-section-numbers.yaml
@@ -1,0 +1,8 @@
+non-sequential-section-numbers-section-1:
+  section-number: 1
+
+non-sequential-section-numbers-section-2:
+  section-number: 2
+
+non-sequential-section-numbers-section-4:
+  section-number: 4

--- a/csfieldguide/tests/chapters/loaders/test_chapter_sections_loader.py
+++ b/csfieldguide/tests/chapters/loaders/test_chapter_sections_loader.py
@@ -186,3 +186,19 @@ class ChapterSectionsLoaderTest(BaseTestWithDB):
             KeyNotFoundError,
             chapter_section_loader.load
         )
+
+    def test_chapters_chapter_section_loader_non_sequential_section_number(self):
+        test_slug = "non-sequential-section-numbers"
+        chapter = self.test_data.create_chapter("1")
+        factory = mock.Mock()
+        chapter_section_loader = ChapterSectionsLoader(
+            factory,
+            chapter,
+            base_path=self.base_path,
+            content_path=test_slug,
+            structure_filename="{}.yaml".format(test_slug),
+        )
+        self.assertRaises(
+            InvalidYAMLValueError,
+            chapter_section_loader.load
+        )


### PR DESCRIPTION
Resolves #773 

Expands on #773 by:

- showing 'not-available-warning' when a chapter or chapter section is not translated in the current language.

- Greying out chapter section links if they are not translated in the current language
