### PR TITLE
Typo and broken link fixes

### DIFF
--- a/csfieldguide/chapters/content/en/coding-compression/sections/the-whole-story.md
+++ b/csfieldguide/chapters/content/en/coding-compression/sections/the-whole-story.md
@@ -1,8 +1,8 @@
 # The whole story!
 
 The details of how compression systems work have been glossed over in this chapter, as we have been more concerned about the file sizes and speed of the methods than how they work.
-Most compression systems are variations of the ideas that have been covered here, although one fundamental method that we haven't mentioned is Huffman coding, which turns out to be useful as the final stage of *all* of the above methods, and is often one of the first topics mentioned in textbooks discussing compression (there's a brief [explanation of it here](http://www.cimt.plymouth.ac.uk/resources/codes/codes_u17_text.pdf)).
-A closely related system is Arithmetic coding (there's an [explanation of it here](http://www.cimt.plymouth.ac.uk/resources/codes/codes_u18_text.pdf)).
+Most compression systems are variations of the ideas that have been covered here, although one fundamental method that we haven't mentioned is Huffman coding, which turns out to be useful as the final stage of *all* of the above methods, and is often one of the first topics mentioned in textbooks discussing compression (there's a brief [explanation of it here](http://www.cimt.org.uk/resources/codes/codes_u17_text.pdf)).
+A closely related system is Arithmetic coding (there's an [explanation of it here](http://www.cimt.org.uk/resources/codes/codes_u18_text.pdf)).
 Also, video compression has been omitted, even though compressing videos saves more space than most kinds of compression.
 Most video compression is based on the "MPEG" standard (Moving Pictures Experts Group).
 There is some information about how this works in the [CS4FN article on "Movie Magic"](http://www.cs4fn.org/films/mpegit.php).
@@ -11,7 +11,7 @@ There is some information about how this works in the [CS4FN article on "Movie M
 
 # Teacher guides for Plymouth resources
 
-Access to teacher guides for the Plymouth resources (linked in the previous paragraph) above are [available here](http://www.cimt.plymouth.ac.uk/resources/codes/).
+Access to teacher guides for the Plymouth resources (linked in the previous paragraph) above are [available here](http://www.cimt.org.uk/resources/codes/).
 
 {panel end}
 

--- a/csfieldguide/chapters/content/en/computer-graphics/sections/further-reading.md
+++ b/csfieldguide/chapters/content/en/computer-graphics/sections/further-reading.md
@@ -4,6 +4,6 @@
 
 - [https://en.wikipedia.org/wiki/Computer_graphics](https://en.wikipedia.org/wiki/Computer_graphics)
 - [https://en.wikipedia.org/wiki/Transformation_matrix](https://en.wikipedia.org/wiki/Transformation_matrix)
-- [https://en.wikipedia.org/wiki/Bresenham’s_line_algorithm](https://en.wikipedia.org/wiki/Bresenhams_line_algorithm)
+- [https://en.wikipedia.org/wiki/Bresenham’s_line_algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm)
 - [https://en.wikipedia.org/wiki/Ray_trace](https://en.wikipedia.org/wiki/Ray_trace)
 - [http://www.povray.org/resources/links/3D_Tutorials/POV-Ray_Tutorials/](http://www.povray.org/resources/links/3D_Tutorials/POV-Ray_Tutorials/)

--- a/csfieldguide/chapters/content/en/computer-graphics/sections/graphics-transformations.md
+++ b/csfieldguide/chapters/content/en/computer-graphics/sections/graphics-transformations.md
@@ -3,7 +3,7 @@
 A computer graphics image is just the result of a whole lot of mathematical calculations.
 In fact, every pixel you see in an image has usually had many calculations made to work out what colour it should be, and there are often millions of pixels in a typical image.
 
-Let's start with some simple but common calculations that are needed for in graphics programming.
+Let's start with some simple but common calculations that are needed in graphics programming.
 The following interactive shows a cube with symbols on each face.
 You can move it around using what's called a *transform*, which simply adjusts where it is placed in space.
 Try typing in 3D coordinates into this interactive to find each code.

--- a/csfieldguide/chapters/content/en/computer-graphics/sections/graphics-transformations.md
+++ b/csfieldguide/chapters/content/en/computer-graphics/sections/graphics-transformations.md
@@ -710,7 +710,6 @@ Discuss how the single matrix derived from all the others is more efficient, usi
 # WebGL and OpenGL
 
 If you're confident with programming and want to explore graphics at a more practical level, you could do a similar project to the previous one using a graphics programming system such as [WebGL](https://en.wikipedia.org/wiki/WebGL) (which is the system used in the demonstrations above), or a widely used graphics system such as [OpenGL](https://en.wikipedia.org/wiki/OpenGL).
-There is an interactive tutorial on OpenGL called [JPOT](http://www.cs.uwm.edu/%7Egrafix2/).
 
 Note that these project can be very time consuming because these are powerful systems,
 and there is quite a bit of detail to get right even for a simple operation.

--- a/csfieldguide/chapters/content/en/computer-vision/sections/further-reading.md
+++ b/csfieldguide/chapters/content/en/computer-vision/sections/further-reading.md
@@ -2,8 +2,6 @@
 
 - [https://en.wikipedia.org/wiki/Computer_vision](https://en.wikipedia.org/wiki/Computer_vision)
 - [https://en.wikipedia.org/wiki/Mri](https://en.wikipedia.org/wiki/Mri)
-- [http://www.cosc.canterbury.ac.nz/mukundan/cogr/applcogr.html](https://web.archive.org/web/20170407014417/http://www.cosc.canterbury.ac.nz/mukundan/cogr/applcogr.html)
-- [http://www.cosc.canterbury.ac.nz/mukundan/covn/applcovn.html](https://web.archive.org/web/20170407014424/http://www.cosc.canterbury.ac.nz/mukundan/covn/applcovn.html)
 
 We also have a Viola-Jones Face Detection interactive available, supporting text will be added at a later date.
 

--- a/csfieldguide/chapters/content/en/data-representation/sections/images-and-colours.md
+++ b/csfieldguide/chapters/content/en/data-representation/sections/images-and-colours.md
@@ -202,7 +202,7 @@ This can be broken up into groups of 4 bits: `1001` `0001` `0011` `0010` `0111` 
 
 And now, each of these groups of 4 bits will need to be represented with a **hexadecimal** digit.
 
-- 1001 -> 5
+- 1001 -> 9
 - 0001 -> 1
 - 0011 -> 3
 - 0010 -> 2
@@ -294,7 +294,7 @@ In other cases, the 16-bit images are almost as good as 24-bit images unless you
 They also use two-thirds (16/24) of the space that they would with 24-bit colour.
 For images that will need to be downloaded on 3G devices where internet is expensive, this is worth thinking about carefully.
 
-Have an experiement with the following interactive, to see what impact different numbers of bits for each colour has.
+Have an experiment with the following interactive, to see what impact different numbers of bits for each colour has.
 Do you think 8 bit colour was right in having 2 bits for blue, or should it have been green or red that got only 2 bits?
 
 {interactive slug="image-bit-comparer" type="whole-page" text="Image Bit Comparer - Change Bits mode" parameters="change-bits=true"}

--- a/csfieldguide/chapters/content/en/data-representation/sections/numbers.md
+++ b/csfieldguide/chapters/content/en/data-representation/sections/numbers.md
@@ -528,7 +528,7 @@ There's an alternative representation called *Two's Complement*, which avoids ha
 ***Representing positive numbers with Two's Complement***
 
 Representing positive numbers is the same as the method you have already learnt.
-Using **8 bits**,the leftmost bit is a zero and the other 7 bits are the usual binary representation of the number; for example, **1** would be **00000001**, and 65 would be **00110010**.
+Using **8 bits**,the leftmost bit is a zero and the other 7 bits are the usual binary representation of the number; for example, **1** would be **00000001**, and **50** would be **00110010**.
 
 ***Representing negative numbers with Two's Complement***
 

--- a/csfieldguide/chapters/content/en/formal-languages/sections/finite-state-automata.md
+++ b/csfieldguide/chapters/content/en/formal-languages/sections/finite-state-automata.md
@@ -667,7 +667,6 @@ The game is available [here](http://pleasingfungus.com/#Manufactoria) and [here]
 
 If you use the Java-based graphical educational system [Greenfoot](http://www.greenfoot.org/door) as a programming environment, the [treasure hunt finite state automata exercise](http://greenroom.greenfoot.org/resources/5) is based on the Treasure Island FSA activity from CS Unplugged.
 Teachers can register at the [Greenroom](http://greenroom.greenfoot.org/door) resources area to download the software.
-Students can interact with the activity, without accessing source code, through: http://www.greenfoot.org/scenarios/1678 .
 
 If you use [Scratch](http://scratch.mit.edu/), the following program is promising, but it doesn't have an activity or guide, and Level 3 students may have progressed beyond Scratch.
 It implements the Finite State Automata CS Unplugged activity in Scratch, and can be downloaded as part of a [zip file](http://code.google.com/p/scratch-unplugged/downloads/detail?name=scratch-unplugged-1-0.zip&can=2&q=) of a full set of Unplugged activities.

--- a/csfieldguide/chapters/content/en/network-communication-protocols/sections/further-reading.md
+++ b/csfieldguide/chapters/content/en/network-communication-protocols/sections/further-reading.md
@@ -3,7 +3,6 @@
 - The [two generals problem](https://en.wikipedia.org/wiki/Two_Generals%27_Problem) is a famous problem in protocols to talk about what happens when you can’t be sure about communication success.
 - What happens if you were to send packets tied to birds? [IP over Avian Carriers](https://en.wikipedia.org/wiki/IP_over_Avian_Carriers)
 - Protocols are found in the strangest of places: [Engine Order Telegraph](https://en.wikipedia.org/wiki/Engine_order_telegraph)
-- Coursera course on [Internet History, Technology, and Security](https://www.coursera.org/learn/insidetheinternet)
 
 ## Videos
 


### PR DESCRIPTION
This PR fixes typos and broken links in the content.
Issues to be closed after merging: #782, #784, #785, #789. #781 can also be closed, note that not all links marked as broken by linkie are actually broken, rather they just take you to a page that requires registration/log in before you can proceed, as indicated by the text in the field guide.
