### PR TITLE
Activate Coding Error Control chapter

### DIFF
--- a/csfieldguide/chapters/content/en/coding-error-control/coding-error-control.md
+++ b/csfieldguide/chapters/content/en/coding-error-control/coding-error-control.md
@@ -20,13 +20,13 @@ The same thing is happening to data stored on computers — while you (or the co
 When the computer reads the data, you don't want it to just use the incorrect values.
 At the least you want it to detect that something has gone wrong, and ideally it should do what the magician did, and put it right.
 
-This chapter is about guarding against errors in data in its many different forms — data stored on a harddrive, on a CD, on a floppy disk, on a solid state drive (such as that inside a cellphone, camera, or mp3 player), data currently in RAM (particularly on servers where the data correctness is critical), data going between the RAM and hard drive or between an external hard drive and the internal hard drive, data currently being processed in the processor or data going over a wired or wireless network such as from your computer to a server on the other side of the world.
+This chapter is about guarding against errors in data in its many different forms — data stored on a harddrive, on a CD, on a floppy disk, on a solid state drive (such as that inside a cellphone, camera, or MP3 player), data currently in RAM (particularly on servers where the data correctness is critical), data going between the RAM and hard drive or between an external hard drive and the internal hard drive, data currently being processed in the processor or data going over a wired or wireless network such as from your computer to a server on the other side of the world.
 It even includes data such as the barcodes printed on products or the number on your credit card.
 
 If we don't detect that data has been changed by some physical problem (such as small scratch on a CD, or a failing circuit in a flash drive), the information will just be used with incorrect values.
 A very poorly written banking system could potentially result in your bank balance being changed if just one of the bits in a number was changed by a cosmic ray affecting a value in the computer's memory!
 If the barcode on the packet of chips you buy from the shop is scanned incorrectly, you might be charged for shampoo instead.
-If you transfer a music file from your laptop to your mp3 player and a few of the bits were transferred incorrectly, the mp3 player might play annoying glitches in the music.
+If you transfer a music file from your laptop to your MP3 player and a few of the bits were transferred incorrectly, the MP3 player might play annoying glitches in the music.
 Error control codes guard against all these things, so that (most of the time) things just work without you having to worry about such errors.
 
 There are several ways that data can be changed accidentally.
@@ -50,4 +50,4 @@ Other error control schemes, such as those that deal with sending data from a se
 Error detection is also used on barcode numbers on products you buy, as well as the unique ISBN (International Standard Book Number) that all books have, and even the 16 digit number on a credit card.
 If any of these numbers are typed or scanned incorrectly, there's a good chance that the error will be detected, and the user can be asked to re-enter the data.
 
-By the end of this chapter, you should understand the basic idea of error control coding, the reasons that we require it, the differences between algorithms that can detect errors and those that can both detect and correct errors, and some of the ways that error control coding is used, in particular parity (focussing on the parity magic trick) and the check digits used to ensure book numbers, barcode numbers, and credit card numbers are entered correctly.
+By the end of this chapter, you should understand the basic idea of error control coding, the reasons that we require it, the differences between algorithms that can detect errors and those that can both detect and correct errors, and some of the ways that error control coding is used. In particular parity (focussing on the parity magic trick) and the check digits used to ensure book numbers, barcode numbers, and credit card numbers are entered correctly.

--- a/csfieldguide/chapters/content/en/coding-error-control/sections/check-digits-on-barcodes.md
+++ b/csfieldguide/chapters/content/en/coding-error-control/sections/check-digits-on-barcodes.md
@@ -15,7 +15,7 @@ In this section we will be initially looking at one of the most commonly used ba
 You don’t have to understand *why* the calculations work so well (this is advanced math, and isn’t important for understanding the overall ideas), and while it is good for you to know what the calculation is, it is not essential.
 So if math is challenging and worrying for you, don’t panic too much because what we are looking at in this section isn’t near as difficult as it might initially appear!
 
-## Check digits On product barcodes
+## Check digits on product barcodes
 
 Most products you can buy at the shop have a barcode on them with a 13 digit "global trade item number" (referred to as GTIN-13).
 The first 12 digits are the actual identification number for the product, the 13th is the check digit calculated from the other 12.
@@ -55,7 +55,7 @@ If only one digit is changed, the check digit will always be incorrect, and the 
 
 Have a look for another product that has a barcode on it, such as a food item from your lunch, or a stationery item.
 Note that some barcodes are a little different — make sure the barcodes that you are using have 13 digits (although you might like to go and find out how the check digit works on some of the other ones).
-Can the interactive is always determine whether or not you typed the barcode correctly?
+Can the interactive always determine whether or not you typed the barcode correctly?
 
 One of the following product numbers has one incorrect digit.
 Can you tell which of the products has had its number typed incorrectly?
@@ -227,7 +227,7 @@ This also means that you can group digits that add to 10 (like 1 and 9, or 5 and
 For example, in the second group, 3+0+7 at the start adds up to 0, and the only sum that counts is 2+4, giving 6 as the total.
 
 Finally, even the multiplication will be ok if you just take the last digit.
-In the example above, that means we end up working out 6x3 giving 8 (not 18); the original was 16x3 giving 48, but it's only the final 8 digit that matters.
+In the example above, that means we end up working out 6x3 giving 8 (not 18); the original was 16x3 giving 48, but it's only the final digit (8) that matters.
 
 All these shortcuts can make it very easy to track the sum in your head.
 

--- a/csfieldguide/chapters/content/en/coding-error-control/sections/further-reading.md
+++ b/csfieldguide/chapters/content/en/coding-error-control/sections/further-reading.md
@@ -1,9 +1,9 @@
 # Further reading
 
-## Useful Links
+## Useful links
 
 - [CS Unplugged Parity Trick](http://csunplugged.org/error-detection)
-- [CS4FN](http://www.cs4fn.org/) has a [free book](http://www.cs4fn.org/magic/) that contains the Parity Trick and a number of other tricks related to computer science.
+- [CS4FN](http://www.cs4fn.org/) has a [free book](http://www.cs4fn.org/magic/) that contains the parity trick and a number of other tricks related to computer science.
 - Techradar has more [information about error detection and correction](http://www.techradar.com/news/computing/how-error-detection-and-correction-works-1080736)
 - [An explanation of error correcting codes](http://www.multiwingspan.co.uk/as1.php?page=error)
 - [A check digit calculator for common bar codes](http://www.gs1.org/barcodes/support/check_digit_calculator)

--- a/csfieldguide/chapters/content/en/coding-error-control/sections/further-reading.md
+++ b/csfieldguide/chapters/content/en/coding-error-control/sections/further-reading.md
@@ -2,7 +2,7 @@
 
 ## Useful links
 
-- [CS Unplugged Parity Trick](http://csunplugged.org/error-detection)
+- [CS Unplugged parity trick](http://csunplugged.org/error-detection)
 - [CS4FN](http://www.cs4fn.org/) has a [free book](http://www.cs4fn.org/magic/) that contains the parity trick and a number of other tricks related to computer science.
 - Techradar has more [information about error detection and correction](http://www.techradar.com/news/computing/how-error-detection-and-correction-works-1080736)
 - [An explanation of error correcting codes](http://www.multiwingspan.co.uk/as1.php?page=error)

--- a/csfieldguide/chapters/content/en/coding-error-control/sections/the-parity-magic-trick.md
+++ b/csfieldguide/chapters/content/en/coding-error-control/sections/the-parity-magic-trick.md
@@ -3,7 +3,7 @@
 If you have never seen the parity magic trick before, check out the video in the "What’s the Big Picture?" section above.
 This section assumes that you know what is meant by the parity magic trick, but now we'll explain how it actually works!
 
-{image file-path="img/chapters/parity-trick-cartoon.jpg" alt="The parity magic trick"}
+{image file-path="img/chapters/parity-trick-cartoon.jpg" alt="The parity magic trick" alignment="left"}
 
 A magician asks an observer to lay out a square grid of two-sided cards, and the magician then says they are going to make it a bit harder, and add an extra row and column to the square.
 The magician then faces the other way while the observer flips over one card.

--- a/csfieldguide/chapters/content/en/coding-error-control/sections/the-parity-magic-trick.md
+++ b/csfieldguide/chapters/content/en/coding-error-control/sections/the-parity-magic-trick.md
@@ -1,4 +1,4 @@
-# The Parity Magic Trick
+# The parity magic trick
 
 If you have never seen the parity magic trick before, check out the video in the "What’s the Big Picture?" section above.
 This section assumes that you know what is meant by the parity magic trick, but now we'll explain how it actually works!
@@ -72,7 +72,7 @@ You can find details and lots of ideas relating to the trick [here](https://www.
 2. Take all the remaining cards, and then say that actually, 5 by 5 is too easy so you are going to make it 6 by 6.
   Instead of adding the new row and column randomly though, you are adding them in the way you did in the interactive (even parity).
   Do this as fast as you can without making errors (it can look very casual if you practise this, even though the cards are being carefully selected).
-3. Tell your friend that you are going to face the other way, and you want them to flip over one card while you are not looking.Check that they've flipped exactly one card.
+3. Tell your friend that you are going to face the other way, and you want them to flip over one card while you are not looking. Check that they've flipped exactly one card.
 4. Turn around again once they have flipped a card, look through the rows and columns, identifying a row and then a column that has an odd number of black cards in it.
   The flipped card will be the one at the intersection of that row and column.
   Flip that card back over.

--- a/csfieldguide/chapters/content/structure/structure.yaml
+++ b/csfieldguide/chapters/content/structure/structure.yaml
@@ -15,8 +15,8 @@ chapters:
   #   chapter-number: 7
   # coding-encryption:
   #   chapter-number: 8
-  # coding-error-control:
-  #   chapter-number: 9
+  coding-error-control:
+    chapter-number: 9
   # artificial-intelligence:
   #   chapter-number: 10
   # complexity-and-tractability:

--- a/csfieldguide/interactives/content/structure/interactives.yaml
+++ b/csfieldguide/interactives/content/structure/interactives.yaml
@@ -37,12 +37,12 @@ binary-mode-calculator:
 # caesar-cipher:
 #   languages:
 #     en: interactives/caesar-cipher.html
-# checksum-calculator:
-#   languages:
-#     en: interactives/checksum-calculator.html
-# checksum-calculator-gtin-13:
-#   languages:
-#     en: interactives/checksum-calculator-gtin-13.html
+checksum-calculator:
+  languages:
+    en: interactives/checksum-calculator.html
+checksum-calculator-gtin-13:
+  languages:
+    en: interactives/checksum-calculator-gtin-13.html
 close-window:
   languages:
     en: interactives/close-window.html
@@ -121,9 +121,9 @@ menu-keystrokes:
 no-help:
   languages:
     en: interactives/no-help.html
-# number-generator:
-#   languages:
-#     en: interactives/number-generator.html
+number-generator:
+  languages:
+    en: interactives/number-generator.html
 off-by-one:
   languages:
     en: interactives/off-by-one.html
@@ -133,9 +133,9 @@ off-by-one:
 # packet-attack-level-creator:
 #   languages:
 #     en: interactives/packet-attack-level-creator.html
-# parity:
-#   languages:
-#     en: interactives/parity.html
+parity:
+  languages:
+    en: interactives/parity.html
 payment-interface:
   languages:
     en: interactives/payment-interface.html

--- a/csfieldguide/static/interactives/parity/js/parity.js
+++ b/csfieldguide/static/interactives/parity/js/parity.js
@@ -27,10 +27,10 @@ $(document).ready(function(){
     // Display status
     if (parity_status) {
       Parity.feedback.removeClass('error');
-      Parity.feedback.text(gettext("Correct: Every row and column has even parity (of white squares)"));
+      Parity.feedback.text(gettext("Correct: Every row and column has even parity (of black squares)"));
     } else {
       Parity.feedback.addClass('error');
-      Parity.feedback.text(gettext("Incorrect: Not every row and column has even parity (of white squares)"));
+      Parity.feedback.text(gettext("Incorrect: Not every row and column has even parity (of black squares)"));
     }
   });
 
@@ -300,15 +300,15 @@ function checkParity() {
 
   column_counts = new Array(Parity.grid_values.length).fill(0);
   for (var row = 0; row < Parity.grid_values.length; row++) {
-    var white_bit_count = 0;
+    var black_bit_count = 0;
     for (var col = 0; col < Parity.grid_values.length; col++) {
       // If white (true) add to counts
-      if (Parity.grid_values[row][col]) {
-        white_bit_count++;
+      if (Parity.grid_values[row][col] == 0) {
+        black_bit_count++;
         column_counts[col]++;
       }
     }
-    if (white_bit_count % 2 == 1) {
+    if (black_bit_count % 2 == 1) {
       parity_status = false;
     }
   }
@@ -329,16 +329,16 @@ function setParityBits() {
 
   column_counts = new Array(Parity.grid_values.length).fill(0);
   for (var row = 0; row < Parity.grid_values.length-1; row++) {
-    var white_bit_count = 0;
+    var black_bit_count = 0;
     for (var col = 0; col < Parity.grid_values.length-1; col++) {
-      // If white (true) add to counts
-      if (Parity.grid_values[row][col]) {
-        white_bit_count++;
+      // If black add to counts
+      if (Parity.grid_values[row][col] == 0) {
+        black_bit_count++;
         column_counts[col]++;
       }
     }
     // Last bit in row
-    if (white_bit_count % 2 == 0) {
+    if (black_bit_count % 2 == 0) {
       Parity.grid_values[row][Parity.grid_values.length-1] = false;
     } else {
       column_counts[Parity.grid_values.length-1]++;

--- a/csfieldguide/templates/interactives/parity.html
+++ b/csfieldguide/templates/interactives/parity.html
@@ -13,7 +13,7 @@
             <h4 id="interactive-parity-mode"></h4>
             <div class="row">
               <div class="col-sm-12 col-md-4">
-                <p class="interactive-parity-text">{% trans "The grid is considered valid if each row and column has an even number of white squares." %}</p>
+                <p class="interactive-parity-text">{% trans "The grid is considered valid if each row and column has an even number of black squares." %}</p>
                 <div class="interactive-parity-controls interactive-parity-trick-controls">
                   <p>
                     {% trans "Click the parity bits in the last row and column to set them correctly. Click the 'Flip a bit' button when you are done." %}


### PR DESCRIPTION
This PR activates the Coding Error Control chapter. It includes some typo/formatting fixes along with a change to the parity interacitve (to count even black squares - (not white) which relates to #769.

NOTE: iframes are not resizing but will be addressed in #827