### PR TITLE
Fix names of MIPS interactives in appendix

### DIFF
--- a/csfieldguide/interactives/content/en/interactives.yaml
+++ b/csfieldguide/interactives/content/en/interactives.yaml
@@ -75,9 +75,9 @@ md5-hash:
 menu-keystrokes:
   name: Menu Keystrokes
 mips-assembler:
-  name: mips-assembler
+  name: MIPS Assembler
 mips-simulator:
-  name: mips-simulator
+  name: MIPS Simulator
 ncea-guide-selector:
   name: ncea-guide-selector (broken)
 nfa-guesser:


### PR DESCRIPTION
This fixes a minor issue where the names of two Interactives in the Appendix were not consistent with surrounding Interactive names. They have been renamed to `MIPS Assembler` and `MIPS Simulator` respectively.
![v](https://user-images.githubusercontent.com/25916475/52922023-4bae7400-3382-11e9-8f5f-be3de6da966c.png)
