### PR TITLE
Fix spelling of hexadecimal in colour matcher interactive

### DIFF
--- a/csfieldguide/static/interactives/colour-matcher/README.md
+++ b/csfieldguide/static/interactives/colour-matcher/README.md
@@ -8,7 +8,7 @@ The goal colour is picked to be impossible to match perfectly with 8 bit values.
 
 ## Usage
 
-The interactive shows binary representation as default, but it can also display hexidecimal by adding the following URL parameter: `?hexidecimal=true`.
+The interactive shows binary representation as default, but it can also display hexadecimal by adding the following URL parameter: `?hexadecimal=true`.
 
 ## Required files
 

--- a/csfieldguide/static/interactives/colour-matcher/js/colour-matcher.js
+++ b/csfieldguide/static/interactives/colour-matcher/js/colour-matcher.js
@@ -18,12 +18,12 @@ $(document).ready(function () {
                               [gettext('Help me set 24 bit green'), 'success'],
                               [gettext('All help given'), 'secondary'],
                             ];
-  ColourMatcher.display_hexidecimal = false;
+  ColourMatcher.display_hexadecimal = false;
 
-  // Display hexidecimal values
-  if (urlParameters.getUrlParameter('hexidecimal') == 'true') {
-    ColourMatcher.display_hexidecimal = true;
-    $('#interactive-colour-matcher .hexidecimal').show();
+  // Display hexadecimal values
+  if (urlParameters.getUrlParameter('hexadecimal') == 'true') {
+    ColourMatcher.display_hexadecimal = true;
+    $('#interactive-colour-matcher .hexadecimal').show();
   }
 
   // Setup 24 bit sliders
@@ -214,8 +214,8 @@ function update24BitPanel(){
     ColourMatcher.bit_24.value_labels[i].innerHTML = binary;
   }
   setBinaryRepresentation('interactive-colour-matcher-bit-representation-24', total_binary);
-  if (ColourMatcher.display_hexidecimal) {
-    setHexidecimalRepresentation('24', colours);
+  if (ColourMatcher.display_hexadecimal) {
+    setHexadecimalRepresentation('24', colours);
   }
 };
 
@@ -242,8 +242,8 @@ function update8BitPanel(){
     ColourMatcher.bit_8.value_labels[i].innerHTML = binary;
   }
   setBinaryRepresentation('interactive-colour-matcher-bit-representation-8', total_binary);
-  if (ColourMatcher.display_hexidecimal) {
-    setHexidecimalRepresentation('8', colours);
+  if (ColourMatcher.display_hexadecimal) {
+    setHexadecimalRepresentation('8', colours);
   }
 
   // Update 8 bit panel
@@ -268,14 +268,14 @@ function setBinaryRepresentation (representation_id, binary_string) {
 };
 
 
-// Set the hexidecimal representation from the given colours
-function setHexidecimalRepresentation(bit, colours) {
-  var hexidecimal = '';
+// Set the hexadecimal representation from the given colours
+function setHexadecimalRepresentation(bit, colours) {
+  var hexadecimal = '';
   for (var i = 0; i < colours.length; i++) {
     value = Number(colours[i]).toString(16);
-    hexidecimal += "00".substr(value.length) + value
+    hexadecimal += "00".substr(value.length) + value
   }
-  $('#interactive-colour-matcher-hexidecimal-representation-' + bit).html(hexidecimal.toUpperCase());
+  $('#interactive-colour-matcher-hexadecimal-representation-' + bit).html(hexadecimal.toUpperCase());
 }
 
 

--- a/csfieldguide/static/interactives/colour-matcher/scss/colour-matcher.scss
+++ b/csfieldguide/static/interactives/colour-matcher/scss/colour-matcher.scss
@@ -59,7 +59,7 @@
   padding-left: 0.5rem;
   margin-bottom: 1rem;
 }
-#interactive-colour-matcher .hexidecimal {
+#interactive-colour-matcher .hexadecimal {
   display: none;
 }
 #interactive-colour-matcher .bordered {
@@ -90,7 +90,7 @@
 #interactive-colour-matcher .representation-text {
   font-family: monospace;
 }
-#interactive-colour-matcher .hexidecimal .representation-text {
+#interactive-colour-matcher .hexadecimal .representation-text {
   font-size: 1.5rem;
 }
 .interactive-colour-matcher-result {

--- a/csfieldguide/static/interactives/mips-assembler/README.md
+++ b/csfieldguide/static/interactives/mips-assembler/README.md
@@ -6,7 +6,7 @@ This interactive allows users to enter MIPS code to see the assembler output.
 
 ## MIPS Assembler License
 
-The [MIPS Assembler](https://github.com/alanhogan/online-mips-assembler) by [Alan Hogan](http://alanhogan.com/) that this interactive is based on is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/). The full licence file can be found in the third-party-licences folder.
+The [MIPS Assembler](https://github.com/alanhogan/online-mips-assembler) by [Alan Hogan](http://alanhogan.com/) that this interactive is based on is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
 
 ## Required Files
 

--- a/csfieldguide/static/interactives/mips-assembler/README.md
+++ b/csfieldguide/static/interactives/mips-assembler/README.md
@@ -1,14 +1,13 @@
 # MIPS Assembler Interactive
 
-**MIPS Assembler Creator:** Alan Hogan
-**Interactive Creator:** Alasdair Smith
+**Author:** Alasdair Smith
 
 This interactive allows users to enter MIPS code to see the assembler output.
 
 ## MIPS Assembler License
 
-The [MIPS Assembler](https://github.com/alanhogan/online-mips-assembler) by [Alan Hogan](http://alanhogan.com/) that this interactive is based on is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
+The [MIPS Assembler](https://github.com/alanhogan/online-mips-assembler) by [Alan Hogan](http://alanhogan.com/) that this interactive is based on is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/). The full licence file can be found in the third-party-licences folder.
 
 ## Required Files
 
-- This interactive uses jQuery and MaterializeCSS (loaded from base-files folder).
+- This interactive uses jQuery and Bootstrap.

--- a/csfieldguide/static/interactives/mips-simulator/README.md
+++ b/csfieldguide/static/interactives/mips-simulator/README.md
@@ -7,7 +7,7 @@ Adding `?offer-examples` to the URL reverals buttons that can be pressed to load
 
 ## MIPS Simulator License
 
-The [MIPS Simulator](https://github.com/alanhogan/miphps-mips-simulator) by [Alan Hogan](http://alanhogan.com/) that this interactive is based on is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/). The full licence file can be found in the third-party-licences folder.
+The [MIPS Simulator](https://github.com/alanhogan/miphps-mips-simulator) by [Alan Hogan](http://alanhogan.com/) that this interactive is based on is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
 
 ## Required Files
 

--- a/csfieldguide/static/interactives/mips-simulator/README.md
+++ b/csfieldguide/static/interactives/mips-simulator/README.md
@@ -1,15 +1,14 @@
 # MIPS Simulator Interactive
 
-**MIPS Simulator Creator:** Alan Hogan
-**Interactive Creator:** Alasdair Smith
+**Author:** Alasdair Smith
 
 This interactive allows users to simulate assembled MIPS code and see the output.
 Adding `?offer-examples` to the URL reverals buttons that can be pressed to load the assembled code from the Assembler interactive.
 
 ## MIPS Simulator License
 
-The [MIPS Simulator](https://github.com/alanhogan/miphps-mips-simulator) by [Alan Hogan](http://alanhogan.com/) that this interactive is based on is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/).
+The [MIPS Simulator](https://github.com/alanhogan/miphps-mips-simulator) by [Alan Hogan](http://alanhogan.com/) that this interactive is based on is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/). The full licence file can be found in the third-party-licences folder.
 
 ## Required Files
 
-- This interactive uses jQuery and MaterializeCSS (loaded from base-files folder).
+- This interactive uses jQuery and Bootstrap.

--- a/csfieldguide/static/interactives/mips-simulator/css/mips-simulator.scss
+++ b/csfieldguide/static/interactives/mips-simulator/css/mips-simulator.scss
@@ -3,14 +3,14 @@
   padding-right: 10rem;
 }
 
-@media screen and (max-width: 1500px) {
+@media screen and (max-width: 1540px) {
   .padded {
     padding-left: 5rem;
     padding-right: 5rem;
   }
 }
 
-@media screen and (max-width: 1300px) {
+@media screen and (max-width: 1380px) {
   .padded {
     padding-left: 20px;
     padding-right: 20px;

--- a/csfieldguide/templates/interactives/colour-matcher.html
+++ b/csfieldguide/templates/interactives/colour-matcher.html
@@ -51,11 +51,11 @@
           <div id="interactive-colour-matcher-bit-representation-24" class="flex-parent">
           </div>
         </div>
-        <div class="section-representation hexidecimal">
+        <div class="section-representation hexadecimal">
           <div class="interactive-colour-matcher-heading">
-            {% trans "<strong>Hexidecimal representation</strong>" %}
+            {% trans "<strong>Hexadecimal representation</strong>" %}
           </div>
-          <div id="interactive-colour-matcher-hexidecimal-representation-24" class='representation-text'></div>
+          <div id="interactive-colour-matcher-hexadecimal-representation-24" class='representation-text'></div>
         </div>
 
         <p>
@@ -106,9 +106,9 @@
           <div id="interactive-colour-matcher-bit-representation-8" class="flex-parent">
           </div>
         </div>
-        <div class="section-representation hexidecimal">
-          <div>{% trans "<strong>Hexidecimal representation</strong>" %}</div>
-          <div id="interactive-colour-matcher-hexidecimal-representation-8" class='representation-text'></div>
+        <div class="section-representation hexadecimal">
+          <div>{% trans "<strong>Hexadecimal representation</strong>" %}</div>
+          <div id="interactive-colour-matcher-hexadecimal-representation-8" class='representation-text'></div>
         </div>
       </div>
 


### PR DESCRIPTION
This fixes the spelling of 'hexadecimal' throughout the Colour Matcher interactive (resolves #879)

Also, because I accidentally did it on the same branch, this resolves minor issues I found in the MIPS interactives:
- Remove references to the CSFG v2.0 `base-files` folder
- Fix padding issue in the Simulator interactive
- Change credit given to Alan Hogan, as the original wording could imply that he created MIPS itself