### PR TITLE
Copy over theme-colours object.

### DIFF
--- a/csfieldguide/static/scss/_core-variables.scss
+++ b/csfieldguide/static/scss/_core-variables.scss
@@ -5,5 +5,12 @@ $csfg-light-teacher: #ff5f54;
 $csu: #cc0423;
 $text-color: $gray-900;
 $theme-colors: (
-    "primary": $csfg-light
+    "primary": $csfg-light,
+    "secondary":  $secondary,
+    "success":    $success,
+    "info":       $info,
+    "warning":    $warning,
+    "danger":     $danger,
+    "light":      $light,
+    "dark":       $dark
 );


### PR DESCRIPTION
This PR brings back all of bootstraps theme colours as they were accidentally overwritten in #932. 

Not super happy with this solution as we have to copy over the _whole_ of the `$theme-colors` map into the sass file. The only way I could find how to update just the one theme colour would mean we would have to import bootstraps` _variables.scss` file before our `_core-variables.scss` file; which will break other things.

There's a discussion about it here: https://github.com/twbs/bootstrap/issues/23112

If anyone wants to dig further go for it.

Resolves #934 