### PR TITLE
Set correct file path for import of codemirror css

### DIFF
--- a/csfieldguide/static/scss/codemirror.scss
+++ b/csfieldguide/static/scss/codemirror.scss
@@ -1,1 +1,1 @@
-@import "../../node_modules/codemirror/lib/codemirror.css";
+@import "node_modules/codemirror/lib/codemirror.css";


### PR DESCRIPTION
Moved the css import to a new file in #941 and forgot to update the file path... Resolves #928 