### PR TITLE
Improve usability of unicode chars and add readme

### DIFF
--- a/csfieldguide/static/interactives/unicode-chars/README.md
+++ b/csfieldguide/static/interactives/unicode-chars/README.md
@@ -1,0 +1,11 @@
+# Unicode Characters Interactive
+
+**Original Author:** Unknown
+**Modified By:** Alasdair Smith 2019
+
+This interactive is created to show the Unicode character associated with each decimal value, and vice versa.
+
+## Required Files
+
+This interactive uses [String.fromCodePoint](https://github.com/mathiasbynens/String.fromCodePoint).
+Its licence is listed in `LICENCE-THIRD-PARTY` with a full copy available in the `third-party-licences` directory.

--- a/csfieldguide/static/interactives/unicode-chars/css/unicode-chars.css
+++ b/csfieldguide/static/interactives/unicode-chars/css/unicode-chars.css
@@ -1,7 +1,0 @@
-label {
-    text-align: left;
-}
-
-#interactive-unicode-chars input {
-    width: 250px;
-}

--- a/csfieldguide/static/interactives/unicode-chars/css/unicode-chars.scss
+++ b/csfieldguide/static/interactives/unicode-chars/css/unicode-chars.scss
@@ -2,7 +2,3 @@
     text-align: left;
     color: #ff0000;
 }
-
-#interactive-unicode-chars input {
-    width: 250px;
-}

--- a/csfieldguide/static/interactives/unicode-chars/css/unicode-chars.scss
+++ b/csfieldguide/static/interactives/unicode-chars/css/unicode-chars.scss
@@ -1,0 +1,16 @@
+.uc-title {
+    text-align: center;
+}
+
+#interactive-unicode-chars-error {
+    text-align: left;
+    color: #ff0000;
+}
+
+label {
+    text-align: left;
+}
+
+#interactive-unicode-chars input {
+    width: 250px;
+}

--- a/csfieldguide/static/interactives/unicode-chars/css/unicode-chars.scss
+++ b/csfieldguide/static/interactives/unicode-chars/css/unicode-chars.scss
@@ -1,14 +1,6 @@
-.uc-title {
-    text-align: center;
-}
-
 #interactive-unicode-chars-error {
     text-align: left;
     color: #ff0000;
-}
-
-label {
-    text-align: left;
 }
 
 #interactive-unicode-chars input {

--- a/csfieldguide/static/interactives/unicode-chars/js/unicode-chars.js
+++ b/csfieldguide/static/interactives/unicode-chars/js/unicode-chars.js
@@ -2,6 +2,13 @@ require('string.fromcodepoint');
 
 var $decimal = $("#interactive-unicode-chars-decimal");
 var $char = $("#interactive-unicode-chars-char");
+var $errorText = $("#interactive-unicode-chars-error");
+
+$(document).ready(function() {
+  $char.val('');
+  $decimal.val('');
+  $errorText.addClass("d-none");
+});
 
 $decimal.keypress(function(event) {
   if (/\d/.exec(String.fromCodePoint(event.keyCode)) == null) {
@@ -10,15 +17,20 @@ $decimal.keypress(function(event) {
 });
 
 $decimal.keyup(function() {
-  return $char.val(String.fromCodePoint(Number($decimal.val())));
-});
-
-$char.keypress(function(event) {
-  if (Array.from($char.val()).length !== 0) {
-    return event.preventDefault();
+  try {
+    $errorText.addClass("d-none");
+    return $char.val(String.fromCodePoint(Number($decimal.val())));
+  } catch(err) {
+    $char.val('');
+    $errorText.removeClass("d-none");
   }
 });
 
+$char.keypress(function() {
+  return $char.val($char.val()[$char.val().length]);
+});
+
 $char.keyup(function() {
+  $errorText.addClass("d-none");
   return $decimal.val($char.val().codePointAt(0));
 });

--- a/csfieldguide/templates/interactives/unicode-chars.html
+++ b/csfieldguide/templates/interactives/unicode-chars.html
@@ -4,12 +4,13 @@
 {% load static %}
 
 {% block html %}
-  <div id="interactive-unicode-chars" class="mb-3">
-    <h4>{% trans "Unicode Characters" %}</h4>
+  <div id="interactive-unicode-chars" class="mb-3 container-fluid">
+    <h4 class="uc-title">{% trans "Unicode Characters" %}</h4>
     <div class="d-flex justify-content-around">
       <div class="d-flex flex-column">
         <label for="interactive-unicode-chars-decimal" class="active">{% trans "Decimal" %}</label>
         <input type="text" id="interactive-unicode-chars-decimal" placeholder="{% trans 'Enter a decimal number' %}" title="Decimal" class="validate form-control" pattern="\d+">
+        <div id="interactive-unicode-chars-error" class="d-none">{% trans 'No corresponding character' %}</div>
       </div>
       <div class="d-flex flex-column">
         <label for="interactive-unicode-chars-char" class="active">{% trans "Character" %}</label>

--- a/csfieldguide/templates/interactives/unicode-chars.html
+++ b/csfieldguide/templates/interactives/unicode-chars.html
@@ -5,14 +5,16 @@
 
 {% block html %}
   <div id="interactive-unicode-chars" class="mb-3 container-fluid">
-    <h4 class="uc-title">{% trans "Unicode Characters" %}</h4>
-    <div class="d-flex justify-content-around">
-      <div class="d-flex flex-column">
+    <div class="row">
+      <div class="col-12">
+        <h4 class="text-center">{% trans "Unicode Characters" %}</h4>
+      </div>
+      <div class="col-12 col-sm-6 px-2 text-left">
         <label for="interactive-unicode-chars-decimal" class="active">{% trans "Decimal" %}</label>
-        <input type="text" id="interactive-unicode-chars-decimal" placeholder="{% trans 'Enter a decimal number' %}" title="Decimal" class="validate form-control" pattern="\d+">
+        <input type="text" id="interactive-unicode-chars-decimal" placeholder="{% trans 'Enter an integer' %}" title="Decimal" class="validate form-control" pattern="\d+">
         <div id="interactive-unicode-chars-error" class="d-none">{% trans 'No corresponding character' %}</div>
       </div>
-      <div class="d-flex flex-column">
+      <div class="col-12 col-sm-6 px-2 text-left">
         <label for="interactive-unicode-chars-char" class="active">{% trans "Character" %}</label>
         <input type="text" id="interactive-unicode-chars-char" placeholder="{% trans 'Enter a character' %}" title="Character" class="validate form-control" maxlength="1">
       </div>

--- a/csfieldguide/templates/interactives/unicode-chars.html
+++ b/csfieldguide/templates/interactives/unicode-chars.html
@@ -5,16 +5,16 @@
 
 {% block html %}
   <div id="interactive-unicode-chars" class="mb-3 container-fluid">
-    <div class="row">
+    <div class="row justify-content-center">
       <div class="col-12">
         <h4 class="text-center">{% trans "Unicode Characters" %}</h4>
       </div>
-      <div class="col-12 col-sm-6 px-2 text-left">
+      <div class="col-lg-3 col-sm-6 px-2">
         <label for="interactive-unicode-chars-decimal" class="active">{% trans "Decimal" %}</label>
         <input type="text" id="interactive-unicode-chars-decimal" placeholder="{% trans 'Enter an integer' %}" title="Decimal" class="validate form-control" pattern="\d+">
         <div id="interactive-unicode-chars-error" class="d-none">{% trans 'No corresponding character' %}</div>
       </div>
-      <div class="col-12 col-sm-6 px-2 text-left">
+      <div class="col-lg-3 col-sm-6 px-2">
         <label for="interactive-unicode-chars-char" class="active">{% trans "Character" %}</label>
         <input type="text" id="interactive-unicode-chars-char" placeholder="{% trans 'Enter a character' %}" title="Character" class="validate form-control" maxlength="1">
       </div>
@@ -27,5 +27,5 @@
 {% endblock css %}
 
 {% block js %}
-    <script type="text/javascript" src="{% static 'interactives/unicode-chars/js/unicode-chars.js' %}"></script>
+  <script type="text/javascript" src="{% static 'interactives/unicode-chars/js/unicode-chars.js' %}"></script>
 {% endblock js %}


### PR DESCRIPTION
- [x] Resolves #922 
  - [x] Fixed layout when opened in full screen from the 'interactives' page
  - [x] The user does not have to delete the input/output on the `Character` side in order to input their own character
  - [x] An error is shown if there is no character for the given decimal
- [x] Resolves #339 by adding a README