### PR TITLE
Fix old chapter link syntax in Algorithms chapter

### DIFF
--- a/csfieldguide/chapters/content/en/algorithms/algorithms.md
+++ b/csfieldguide/chapters/content/en/algorithms/algorithms.md
@@ -113,7 +113,7 @@ That's worth knowing in advance because we usually need our programs to scale up
 The formal term for working out the cost of an algorithm is [algorithm analysis](https://en.wikipedia.org/wiki/Analysis_of_algorithms), and we often refer to the cost as the algorithm's *complexity*.
 The most common complexity is the "time complexity" (a rough idea of how long it takes to run), but often the "space complexity" is of interest - how much memory or disk space will the algorithm use up when it's running?
 
-There's more about how the cost of an algorithm is described in industry, using a widely agreed on convention called 'Big-O Notation', in the ["The whole story!"](chapters/algorithms.html#the-whole-story) section at the end of this chapter.
+There's more about how the cost of an algorithm is described in industry, using a widely agreed on convention called 'Big-O Notation', in the ["The whole story!"](the-whole-story) section at the end of this chapter.
 
 {panel end}
 


### PR DESCRIPTION
Resolves #899 

Things of note I found when using the syntax `[text](link)`:
- If link is a url it will link to the url (as expected)
- If link == `/link` (ie is prefixed with `/`) it will append link to the base url (e.g: `localhost:81/link`). This becomes useful because the language code is added automatically (e.g: `localhost:81/en/link`)
- If link is not prefixed with `/`, link will be appended to the current url (e.g: `[full-current-url]/link`). This is what is done here
