### PR TITLE
Add crossorigin attribute to canvas elements.

### DIFF
--- a/csfieldguide/templates/interactives/image-bit-comparer.html
+++ b/csfieldguide/templates/interactives/image-bit-comparer.html
@@ -35,7 +35,7 @@
           <div id="interactive-image-bit-comparer-canvas-parent-container"></div>
 
           <!-- Source canvas for loading images, hidden from user -->
-          <canvas id="interactive-image-bit-comparer-source-canvas"></canvas>
+          <canvas id="interactive-image-bit-comparer-source-canvas" crossorigin="anonymous"></canvas>
         </div>
       </div>
     </div>

--- a/csfieldguide/templates/interactives/jpeg-compression.html
+++ b/csfieldguide/templates/interactives/jpeg-compression.html
@@ -8,8 +8,8 @@
   <div class="row left-align" id="images">
     <div class="col-sm-12 col-md-12 col-lg-4" id="big-image">
       <h6>{% trans "Drag the square around the image:" %}</h6>
-      <canvas id="before-image-canvas" width="360" height="240"></canvas>
-      <canvas style="display:none" id="placeholder-canvas" width="8" height="8"></canvas>
+      <canvas id="before-image-canvas" width="360" height="240" crossorigin="anonymous"></canvas>
+      <canvas style="display:none" id="placeholder-canvas" width="8" height="8" crossorigin="anonymous"></canvas>
       <div class="draggable" id="little-drag-square"></div>
     </div>
     <div class="col-sm-12 col-md-12 col-lg-4" id="puzzle-stuff">
@@ -23,7 +23,7 @@
     </div>
     <div class="col-sm-6 col-md-4 col-lg-3" id="before">
       <h6>{% trans "Original Image Pixels" %}</h6>
-      <canvas id="before-8-by-8" width="240" height="240"></canvas>
+      <canvas id="before-8-by-8" width="240" height="240" crossorigin="anonymous"></canvas>
       <table id="before-labels-8-by-8" width="240" height="240"></table>
       <div class="switch" id="toggleNumberBefore">
         <label>{% trans "Display numbers:" %}
@@ -32,7 +32,7 @@
     </div>
     <div class="col-sm-6 col-md-4 col-lg-3" id="after">
       <h6>{% trans "Processed Image Pixels" %}</h6>
-      <canvas id="after-8-by-8" width="240" height="240"></canvas>
+      <canvas id="after-8-by-8" width="240" height="240" crossorigin="anonymous"></canvas>
       <table id="after-labels-8-by-8" width="240" height="240"></table>
       <div class="switch" id="toggleDifference">
         <label>{% trans "Difference Values:" %}

--- a/csfieldguide/templates/interactives/pixel-viewer.html
+++ b/csfieldguide/templates/interactives/pixel-viewer.html
@@ -19,7 +19,7 @@
         <div id="pixel-viewer-interactive-container">
             <img id="pixel-viewer-interactive-original-image" />
             <div id="pixel-viewer-interactive-loader"></div>
-            <canvas id="pixel-viewer-interactive-content"></canvas>
+            <canvas id="pixel-viewer-interactive-content" crossorigin="anonymous"></canvas>
             <div id="pixel-viewer-interactive-settings" class="menu-offscreen p-3">
                 <h3>
                     {% trans "Pixel Value Interactive" %}


### PR DESCRIPTION
Add `crossorigin="anonymous"` to canvas elements so that canvas elements are no longer tainted by cross-origin data.

See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for in depth info.

Note that the `viola-jones` interactive also uses canvas elements so it will need to also be updated in #924 

(related to #878)