### PR TITLE
Prevent canvas from being tainted by setting the crossorigin attribute in the JavaScript..

### DIFF
--- a/csfieldguide/static/interactives/image-bit-comparer/js/image-bit-comparer.js
+++ b/csfieldguide/static/interactives/image-bit-comparer/js/image-bit-comparer.js
@@ -259,6 +259,7 @@ function loadImage() {
 function initialCanvasData() {
   var source_canvas = document.getElementById('interactive-image-bit-comparer-source-canvas');
   var source_canvas_context = source_canvas.getContext('2d');
+  source_canvas_context.crosOrigin = 'anonymous';
   var source_image_data = source_canvas_context.getImageData(0,
                                                              0,
                                                              ImageBitComparer.BASE_WIDTH * ImageBitComparer.scale_factor,

--- a/csfieldguide/static/interactives/image-bit-comparer/js/image-bit-comparer.js
+++ b/csfieldguide/static/interactives/image-bit-comparer/js/image-bit-comparer.js
@@ -259,7 +259,7 @@ function loadImage() {
 function initialCanvasData() {
   var source_canvas = document.getElementById('interactive-image-bit-comparer-source-canvas');
   var source_canvas_context = source_canvas.getContext('2d');
-  source_canvas_context.crosOrigin = 'anonymous';
+  source_canvas_context.crossOrigin = 'anonymous';
   var source_image_data = source_canvas_context.getImageData(0,
                                                              0,
                                                              ImageBitComparer.BASE_WIDTH * ImageBitComparer.scale_factor,

--- a/csfieldguide/static/interactives/jpeg-compression/js/jpeg-compression.js
+++ b/csfieldguide/static/interactives/jpeg-compression/js/jpeg-compression.js
@@ -255,10 +255,13 @@ $(function () {
     }
 
     var bigCanvasContext = document.getElementById("before-image-canvas").getContext("2d");
+    bigCanvasContext.crossOrigin = 'anonymous';
     var smallCanvasBefore = document.getElementById("before-8-by-8");
     var smallCanvasBeforeContext = smallCanvasBefore.getContext("2d");
+    smallCanvasBeforeContext.crossOrigin = 'anonymous';
     var smallCanvasAfter = document.getElementById("after-8-by-8");
     var smallCanvasAfterContext = smallCanvasAfter.getContext("2d");
+    smallCanvasAfterContext.crossOrigin = 'anonymous';
 
     var quantisation = [16, 11, 12, 15, 21, 32, 50, 66, 11, 12, 13, 18, 24, 46, 62, 73, 12, 13,
         16, 23, 38, 56, 73, 75, 15, 18, 23, 29, 53, 75, 83, 83, 21, 24, 38, 53, 68, 95, 103, 103, 32, 46,
@@ -601,6 +604,7 @@ $(function () {
     // Load image and then replace it with the greyscale version of itself.
     function createBigImage() {
         var img = new Image();
+        img.crossOrigin = 'anonymous';
         img.src = base_path + "interactives/jpeg-compression/img/IMG_5035.jpg";
         img.onload = function () {
             bigCanvasContext.drawImage(img, 0, 0, 360, 240);

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -785,6 +785,7 @@ function createPicturePicker(){
     var img_url = image_base_path + images[i]
     main_div.append(
       $("<img>")
+      .attr('crossorigin', 'anonymous')
       .attr('src', img_url)
       .attr('class', 'img-pick')
       .click(function(){load_resize_image(this.src, false);})
@@ -843,7 +844,9 @@ function get_pixel_data(col, row){
     return [255,255,255]
   } else if (piccache[col][row] == null){
     // Otherwise if we haven't already cached this then cache it
-    var value = source_canvas.getContext('2d').getImageData(col, row, 1, 1).data;
+    var source_canvas_context = source_canvas.getContext('2d');
+    source_canvas_context.crossOrigin = 'anonymous';
+    var value = source_canvas_context.getImageData(col, row, 1, 1).data;
     piccache[col][row] = value;
     return value;
   } else {

--- a/csfieldguide/static/interactives/viola-jones-face-detector/js/viola-jones.js
+++ b/csfieldguide/static/interactives/viola-jones-face-detector/js/viola-jones.js
@@ -265,6 +265,7 @@ function loadResizeImage(src) {
   var sourceImage = document.getElementById('img');
   var MAX_WIDTH = 900;
   var img = new Image();
+  img.crossOrigin = 'anonymous';
   img.src = sourceImage.src;
   img.onload = function() {
     context.clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
In #955 we set the crossorigin attribute to 'anonymous' in the HTML templates. However we also needed to set this on canvas elements in the JavaScipt files (for the canvas elements that get canvas methods run on them - such as getImageData).

Will not know if this resolves our problem until it is merged into develop..

Relates to #878 