### PR TITLE
At the end of each chapter, link to the next

### DIFF
--- a/csfieldguide/chapters/views.py
+++ b/csfieldguide/chapters/views.py
@@ -63,7 +63,7 @@ class ChapterSectionView(generic.DetailView):
             ChapterSection object (ChapterSection).
 
         Raises:
-           404 error: if oject cannot be found.
+           404 error: if object cannot be found.
         """
         return get_object_or_404(
             self.model.objects.select_related(),
@@ -86,6 +86,9 @@ class ChapterSectionView(generic.DetailView):
         context["next_section"] = ChapterSection.objects.filter(
             chapter=self.object.chapter,
             number=current_section_number + 1
+        )
+        context["next_chapter"] = Chapter.objects.filter(
+            number=self.object.chapter.number + 1
         )
         context["chapter"] = self.object.chapter
         return context

--- a/csfieldguide/templates/chapters/chapter_section.html
+++ b/csfieldguide/templates/chapters/chapter_section.html
@@ -36,6 +36,10 @@
       <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn btn-primary float-right {% if not chapter_section.translation_available %} text-muted{% endif %}">
         Next: {{ next_section.0.name }}
       </a>
+    {% elif next_chapter %}
+      <a id="section-next-btn" href="{% url 'chapters:chapter' next_chapter.0.slug %}" class="btn btn-primary float-right {% if not chapter.translation_available %} text-muted{% endif %}">
+        Next: {{ next_chapter.0.name }}
+      </a>
     {% endif %}
   </div>
 {% endblock left_column_content %}


### PR DESCRIPTION
Resolves #884 

![image](https://user-images.githubusercontent.com/25916475/58058578-9deb7500-7bbd-11e9-9e54-fb2e2ed7f321.png)

## Limitations

For any chapter number `x`, the end of the chapter will attempt to link to chapter number `x+1`. If it doesn't find one it doesn't make the link, even if for example chapter number `x+2` does exist. On the current version of the dev site (at time of writing), chapters 3 (prog lang) and 13 (comp vision) are commented out as they are not ready for release. As such chapters 2 and 12 (as well as the final one of course) won't have links to the next chapters. This is only a minor issue because we can expect that all chapters will be available on release.

If there is a missing chapter section number an error is thrown during the build/update process, so it will never link to the next chapter with chapter sections still remaining

![image](https://user-images.githubusercontent.com/25916475/58058798-721cbf00-7bbe-11e9-91e1-c2fec06a91ae.png)

## Also

While doing this I noticed several sentences without `trans` tags, didn't add them in case they are done elsewhere somehow.