### PR TITLE
Highlight glossary terms appropriately.

### DIFF
--- a/csfieldguide/chapters/views.py
+++ b/csfieldguide/chapters/views.py
@@ -136,10 +136,12 @@ def glossary_json(request, **kwargs):
             GlossaryTerm,
             slug=glossary_slug
         )
+        is_translated = get_language() in glossary_item.languages
         data = {
             "slug": glossary_slug,
             "term": glossary_item.term,
-            "definition": render_html_with_load_tags(glossary_item.definition)
+            "definition": render_html_with_load_tags(glossary_item.definition),
+            "translated": is_translated
         }
         return JsonResponse(data)
     else:

--- a/csfieldguide/static/js/website.js
+++ b/csfieldguide/static/js/website.js
@@ -53,10 +53,11 @@ function update_glossary_modal(data) {
   glossary_modal.attr("data-glossary-term", data.slug);
   $("#glossary-modal-term").text(data.term);
   $("#glossary-modal-definition").html(data.definition);
+  console.log(data);
   if (data.translated) {
-    $("#glossary-modal-translation-unavailable").css({ "display": "none"});
+    $("#glossary-modal-translation-unavailable").addClass("d-none");
   } else {
-    $("#glossary-modal-translation-unavailable").css({ "display": "block"});
+    $("#glossary-modal-translation-unavailable").removeClass("d-none");
   }
 }
 

--- a/csfieldguide/static/js/website.js
+++ b/csfieldguide/static/js/website.js
@@ -53,7 +53,6 @@ function update_glossary_modal(data) {
   glossary_modal.attr("data-glossary-term", data.slug);
   $("#glossary-modal-term").text(data.term);
   $("#glossary-modal-definition").html(data.definition);
-  console.log(data);
   if (data.translated) {
     $("#glossary-modal-translation-unavailable").addClass("d-none");
   } else {

--- a/csfieldguide/static/scss/website.scss
+++ b/csfieldguide/static/scss/website.scss
@@ -219,3 +219,13 @@ a {
     color: #0034b4;
   }
 }
+
+.glossary-term {
+  color: #212529;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+
+  &:hover {
+    color: #212529;
+  }
+}

--- a/csfieldguide/templates/base.html
+++ b/csfieldguide/templates/base.html
@@ -290,7 +290,7 @@
               </button>
             </div>
             <div class="modal-body">
-              <div class="alert alert-danger" role="alert" id="glossary-modal-translation-unavailable">
+              <div class="alert alert-danger d-none" role="alert" id="glossary-modal-translation-unavailable">
                 {% blocktrans trimmed with language=current_language.name_local %}
                   This definition is not available in {{ language }}, sorry!
                 {% endblocktrans %}

--- a/csfieldguide/tests/chapters/views/test_glossary_view.py
+++ b/csfieldguide/tests/chapters/views/test_glossary_view.py
@@ -111,7 +111,8 @@ class GlossaryViewTest(BaseTestWithDB):
             {
                 "definition": "<p>Algorithms definition.</p>",
                 "slug": "algorithm",
-                "term": "Algorithms"
+                "term": "Algorithms",
+                "translated": True
             }
         )
 
@@ -139,7 +140,8 @@ class GlossaryViewTest(BaseTestWithDB):
             {
                 "definition": "<p>Pixel definition.</p>",
                 "slug": "pixel",
-                "term": "Pixel"
+                "term": "Pixel",
+                "translated": True
             }
         )
 
@@ -166,3 +168,25 @@ class GlossaryViewTest(BaseTestWithDB):
         url = reverse("chapters:glossary_json")
         response = self.client.get(url, {"word": "pixel"})
         self.assertEqual(404, response.status_code)
+    
+    def test_chapters_glossary_view_json_no_translation(self):
+        term = GlossaryTerm(
+            slug="algorithm",
+            term="Algorithms",
+            definition="<p>Algorithms definition.</p>",
+            languages=["de"],
+        )
+        term.save()
+
+        url = reverse("chapters:glossary_json")
+        response = self.client.get(url, {"term": "algorithm"})
+        self.assertEqual(200, response.status_code)
+        self.assertJSONEqual(
+            str(response.content, encoding="utf8"),
+            {
+                "definition": "<p>Algorithms definition.</p>",
+                "slug": "algorithm",
+                "term": "Algorithms",
+                "translated": False
+            }
+        )

--- a/csfieldguide/tests/chapters/views/test_glossary_view.py
+++ b/csfieldguide/tests/chapters/views/test_glossary_view.py
@@ -168,7 +168,7 @@ class GlossaryViewTest(BaseTestWithDB):
         url = reverse("chapters:glossary_json")
         response = self.client.get(url, {"word": "pixel"})
         self.assertEqual(404, response.status_code)
-    
+
     def test_chapters_glossary_view_json_no_translation(self):
         term = GlossaryTerm(
             slug="algorithm",

--- a/csfieldguide/utils/custom_converter_templates/glossary-link.html
+++ b/csfieldguide/utils/custom_converter_templates/glossary-link.html
@@ -1,0 +1,4 @@
+<a class="glossary-term" data-toggle="modal" 
+ data-glossary-term="{{ term }}"
+ href="{{ id }}"
+ {% if id %} id="{{ id }}" {% endif %}>{{ text }}</a>


### PR DESCRIPTION
Currently glossary terms/links are not distinguishable from plain text. This PR adds a dotted line under the glossary terms/links.

It also adds the `translated` json data field to indicate whether a translation for the current language exists for the glossary definition. This fixes the issue of a translation error appearing even though the translation is available (`data.translated` was always undefined so an error was always displayed).

Note that I have not been able to test this for languages other than English as there are currently no glossary links in other language markdown files.

Resolves #862 