### PR TITLE
add configuration options to pixel viewer

### DIFF
--- a/csfieldguide/static/interactives/pixel-viewer/README.md
+++ b/csfieldguide/static/interactives/pixel-viewer/README.md
@@ -1,9 +1,9 @@
 # Pixel Viewer Interactive
 
 **Author:** Jack Morgan  
-**Updated by:** Andy Bell
+**Modified by:** Andy Bell, Courtney Bracefield, Alasdair Smith
 
-This interactive is created to allow users to see the values of each pixels of an image.
+This interactive is created to allow users to see the values of each pixel of an image.
 The user can zoom in and out of the image, and when close enough the pixel values are displayed.
 
 ## Usage
@@ -33,5 +33,5 @@ Its licence, and others, is listed in the `license.md` file.
 
 ## Future Plans
 
-- Investigate performance increases as the interactive is sluggish when zooming out and viewing many pixels. A possible option may include not creating image with pixels until the image is zoomed in, or use a magnifying glass approach to highlight the each being zoomed.
+- Investigate performance increases as the interactive is sluggish when zooming out and viewing many pixels. A possible option may include not creating image with pixels until the image is zoomed in, or use a magnifying glass approach to highlight just a few pixels at a time.
 - Investigate the original image sizing, as images are currently resized to a small amount to lower the number of pixels to create.

--- a/csfieldguide/templates/interactives/pixel-viewer.html
+++ b/csfieldguide/templates/interactives/pixel-viewer.html
@@ -22,10 +22,10 @@
             <canvas id="pixel-viewer-interactive-content" crossorigin="anonymous"></canvas>
             <div id="pixel-viewer-interactive-settings" class="menu-offscreen p-3">
                 <h3 id="pixel-viewer-interactive-title">
-                    {% trans "Pixel Value Interactive" %}
+                    {% trans "Pixel Viewer Interactive" %}
                 </h3>
-                <p>{% blocktrans %}This interactive allows you to see the pixels of an image, and details about those pixels. <strong>Zoom
-                        in</strong> to see details about individual pixels.{% endblocktrans %}</p>
+                <p>{% blocktrans %}This interactive allows you to see the pixels of an image, and details about those pixels. <strong>Click Zoom
+                        In</strong> to see details about individual pixels.{% endblocktrans %}</p>
 
                 <p id="pixel-viewer-extra-feature-description"></p>
 
@@ -39,6 +39,23 @@
                     <input id="pixel-viewer-interactive-show-pixel-fill" type="checkbox" checked="checked">
                     {% trans "Show pixel background" %}
                 </label>
+                <div class="dropdown">
+                    <button class="btn btn-secondary dropdown-toggle" type="button" id="configSelector" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        {% trans 'Reload with a different configuration' %}
+                    </button>
+                    <div class="dropdown-menu" aria-labelledby="configSelector">
+                        <a class="dropdown-item" href="{% url 'interactives:interactive' 'pixel-viewer' %}">
+                            {% trans 'Default' %}</a>
+                        <a class="dropdown-item" href="{% url 'interactives:interactive' 'pixel-viewer' %}?mode=threshold&picturepicker">
+                            {% trans 'Colour Threshold' %}</a>
+                        <a class="dropdown-item" href="{% url 'interactives:interactive' 'pixel-viewer' %}?mode=thresholdgreyscale&picturepicker">
+                            {% trans 'Greyscale Threshold' %}</a>
+                        <a class="dropdown-item" href="{% url 'interactives:interactive' 'pixel-viewer' %}?mode=blur&picturepicker">
+                            {% trans 'Blur' %}</a>
+                        <a class="dropdown-item" href="{% url 'interactives:interactive' 'pixel-viewer' %}?mode=edgedetection&picturepicker">
+                            {% trans 'Edge Detection' %}</a>
+                    </div>
+                </div>
 
                 <hr>
 


### PR DESCRIPTION
Resolves #964, though I didn't worry about having the option only appear if the interactive was loaded without a config