### PR TITLE
Align chapter section buttons better if they don't fit in one line

### DIFF
--- a/csfieldguide/static/scss/website.scss
+++ b/csfieldguide/static/scss/website.scss
@@ -95,6 +95,15 @@ body {
   cursor: pointer;
 }
 
+.btn-chapter-section {
+  max-width: 40%;
+  white-space: normal;
+  @include media-breakpoint-down(md) {
+    max-width: 100%;
+    min-width: 100%;
+  }
+}
+
 ol, ul {
     margin-bottom: 1rem !important;
 }

--- a/csfieldguide/static/scss/website.scss
+++ b/csfieldguide/static/scss/website.scss
@@ -98,10 +98,6 @@ body {
 .btn-chapter-section {
   max-width: 40%;
   white-space: normal;
-  @include media-breakpoint-down(md) {
-    max-width: 100%;
-    min-width: 100%;
-  }
 }
 
 ol, ul {

--- a/csfieldguide/templates/chapters/chapter_section.html
+++ b/csfieldguide/templates/chapters/chapter_section.html
@@ -26,18 +26,18 @@
     {% endwith %}
   {% endif %}
 
-  <div class="{% if previous_section %}d-flex justify-content-between{% endif %}">
+  <div class="{% if previous_section %}justify-content-between{% endif %}">
     {% if previous_section %}
-      <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn btn-primary mb-2 float-left {% if not chapter_section.translation_available %} text-muted{% endif %}" style="max-width: 50%; white-space: normal;">
+      <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn btn-primary btn-chapter-section mb-2 float-left {% if not chapter_section.translation_available %} text-muted{% endif %}">
         {% trans 'Previous:' %} {{ previous_section.0.name }}
       </a>
     {% endif %}
     {% if next_section %}
-      <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn btn-primary mb-2 float-right {% if not chapter_section.translation_available %} text-muted{% endif %}" style="max-width: 50%; white-space: normal;">
+      <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn btn-primary btn-chapter-section mb-2 float-right {% if not chapter_section.translation_available %} text-muted{% endif %}">
         {% trans 'Next:' %} {{ next_section.0.name }}
       </a>
     {% elif next_chapter %}
-      <a id="section-next-btn" href="{% url 'chapters:chapter' next_chapter.0.slug %}" class="btn btn-primary mb-2 float-right {% if not chapter.translation_available %} text-muted{% endif %}" style="max-width: 50%; white-space: normal;">
+      <a id="section-next-btn" href="{% url 'chapters:chapter' next_chapter.0.slug %}" class="btn btn-primary btn-chapter-section mb-2 float-right {% if not chapter.translation_available %} text-muted{% endif %}">
         {% trans 'Next:' %} {{ next_chapter.0.name }}
       </a>
     {% endif %}

--- a/csfieldguide/templates/chapters/chapter_section.html
+++ b/csfieldguide/templates/chapters/chapter_section.html
@@ -26,18 +26,18 @@
     {% endwith %}
   {% endif %}
 
-  <div>
+  <div class="{% if previous_section %}d-flex flex-wrap justify-content-between{% endif %}">
     {% if previous_section %}
-      <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn btn-primary float-left mb-2 {% if not chapter_section.translation_available %} text-muted{% endif %}">
+      <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn btn-primary mb-2 float-left {% if not chapter_section.translation_available %} text-muted{% endif %}">
         {% trans 'Previous:' %} {{ previous_section.0.name }}
       </a>
     {% endif %}
     {% if next_section %}
-      <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn btn-primary float-right {% if not chapter_section.translation_available %} text-muted{% endif %}">
+      <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn btn-primary mb-2 float-right {% if not chapter_section.translation_available %} text-muted{% endif %}">
         {% trans 'Next:' %} {{ next_section.0.name }}
       </a>
     {% elif next_chapter %}
-      <a id="section-next-btn" href="{% url 'chapters:chapter' next_chapter.0.slug %}" class="btn btn-primary float-right {% if not chapter.translation_available %} text-muted{% endif %}">
+      <a id="section-next-btn" href="{% url 'chapters:chapter' next_chapter.0.slug %}" class="btn btn-primary mb-2 float-right {% if not chapter.translation_available %} text-muted{% endif %}">
         {% trans 'Next:' %} {{ next_chapter.0.name }}
       </a>
     {% endif %}

--- a/csfieldguide/templates/chapters/chapter_section.html
+++ b/csfieldguide/templates/chapters/chapter_section.html
@@ -26,7 +26,7 @@
     {% endwith %}
   {% endif %}
 
-  <div class="{% if previous_section %}d-flex flex-wrap justify-content-between{% endif %}">
+  <div>
     {% if previous_section %}
       <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn btn-primary mb-2 float-left {% if not chapter_section.translation_available %} text-muted{% endif %}">
         {% trans 'Previous:' %} {{ previous_section.0.name }}

--- a/csfieldguide/templates/chapters/chapter_section.html
+++ b/csfieldguide/templates/chapters/chapter_section.html
@@ -26,19 +26,19 @@
     {% endwith %}
   {% endif %}
 
-  <div class="{% if previous_section %}justify-content-between{% endif %}">
+  <div class="{% if previous_section %}d-flex justify-content-between{% endif %}">
     {% if previous_section %}
       <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn btn-primary btn-chapter-section mb-2 float-left {% if not chapter_section.translation_available %} text-muted{% endif %}">
-        {% trans 'Previous:' %} {{ previous_section.0.name }}
+        <strong>{% trans 'Previous:' %}</strong><br>{{ previous_section.0.name }}
       </a>
     {% endif %}
     {% if next_section %}
       <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn btn-primary btn-chapter-section mb-2 float-right {% if not chapter_section.translation_available %} text-muted{% endif %}">
-        {% trans 'Next:' %} {{ next_section.0.name }}
+        <strong>{% trans 'Next:' %}</strong><br>{{ next_section.0.name }}
       </a>
     {% elif next_chapter %}
       <a id="section-next-btn" href="{% url 'chapters:chapter' next_chapter.0.slug %}" class="btn btn-primary btn-chapter-section mb-2 float-right {% if not chapter.translation_available %} text-muted{% endif %}">
-        {% trans 'Next:' %} {{ next_chapter.0.name }}
+        <strong>{% trans 'Next:' %}</strong><br>{{ next_chapter.0.name }}
       </a>
     {% endif %}
   </div>

--- a/csfieldguide/templates/chapters/chapter_section.html
+++ b/csfieldguide/templates/chapters/chapter_section.html
@@ -26,18 +26,18 @@
     {% endwith %}
   {% endif %}
 
-  <div>
+  <div class="{% if previous_section %}d-flex justify-content-between{% endif %}">
     {% if previous_section %}
-      <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn btn-primary mb-2 float-left {% if not chapter_section.translation_available %} text-muted{% endif %}">
+      <a href="{% url 'chapters:chapter_section' chapter.slug previous_section.0.slug %}" class="btn btn-primary mb-2 float-left {% if not chapter_section.translation_available %} text-muted{% endif %}" style="max-width: 50%; white-space: normal;">
         {% trans 'Previous:' %} {{ previous_section.0.name }}
       </a>
     {% endif %}
     {% if next_section %}
-      <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn btn-primary mb-2 float-right {% if not chapter_section.translation_available %} text-muted{% endif %}">
+      <a id="section-next-btn" href="{% url 'chapters:chapter_section' chapter.slug next_section.0.slug %}" class="btn btn-primary mb-2 float-right {% if not chapter_section.translation_available %} text-muted{% endif %}" style="max-width: 50%; white-space: normal;">
         {% trans 'Next:' %} {{ next_section.0.name }}
       </a>
     {% elif next_chapter %}
-      <a id="section-next-btn" href="{% url 'chapters:chapter' next_chapter.0.slug %}" class="btn btn-primary mb-2 float-right {% if not chapter.translation_available %} text-muted{% endif %}">
+      <a id="section-next-btn" href="{% url 'chapters:chapter' next_chapter.0.slug %}" class="btn btn-primary mb-2 float-right {% if not chapter.translation_available %} text-muted{% endif %}" style="max-width: 50%; white-space: normal;">
         {% trans 'Next:' %} {{ next_chapter.0.name }}
       </a>
     {% endif %}


### PR DESCRIPTION
Resolves #949 
The d-flex options override justify-left/-right when applicable. This allows the buttons to maintain the same height if one of them has to wrap text