### PR TITLE
Revert syntax for translated Verto tags in Spanish

### DIFF
--- a/csfieldguide/chapters/content/es/human-computer-interaction/human-computer-interaction.md
+++ b/csfieldguide/chapters/content/es/human-computer-interaction/human-computer-interaction.md
@@ -46,7 +46,7 @@ El *error de captura* se da cuando nos acostumbramos a una ruta o un procedimien
 
 Mucha gente se culpa a sí misma por estos errores, pero la psicología básica nos dice que se trata de un error natural y un buen sistema debería proteger a los usuarios de tales errores (por ejemplo, permitiendo que los deshagan).
 
-{comentario Se pueden analizar las funciones de un botón como ejemplo de precisión en los detalles (arrastrar mientras se presiona, etc.); se puede añadir una actividad interactiva con una casilla simple (normal) y un botón (y quizá un menú) aquí para que el lector pueda experimentar con lo que sucede (por ej. hacer clic pero deslizando antes de soltar)}
+{comment Se pueden analizar las funciones de un botón como ejemplo de precisión en los detalles (arrastrar mientras se presiona, etc.); se puede añadir una actividad interactiva con una casilla simple (normal) y un botón (y quizá un menú) aquí para que el lector pueda experimentar con lo que sucede (por ej. hacer clic pero deslizando antes de soltar)}
 
 El diseño de buenas interfaces es *muy* difícil. Justo cuando crees que tienes una idea inteligente, descubres que hay un grupo de gente que no consigue averiguar cómo usarla o ves que falla en alguna situación. O lo que es peor, algunos desarrolladores piensan que sus usuarios son tontos y que todos los problemas con la interfaz son culpa del usuario y no del desarrollador. Pero el problema real es que el desarrollador conoce muy bien el sistema, mientras que el usuario solo quiere realizar sus tareas sin tener que pasar mucho tiempo aprendiendo a usar el programa. Si es muy difícil de usar y hay otras alternativas, el usuario buscará algo que le resulte más sencillo. ¡Las buenas interfaces valen mucho en el mercado!
 

--- a/csfieldguide/chapters/content/es/human-computer-interaction/sections/the-whole-story.md
+++ b/csfieldguide/chapters/content/es/human-computer-interaction/sections/the-whole-story.md
@@ -14,7 +14,7 @@ Hay muchas otras ideas de la psicología, la fisiología, la sociología e inclu
 
 Existen muchas más leyes, observaciones y directrices sobre el diseño de interfaces que tienen en cuenta el comportamiento humano y el funcionamiento del cuerpo humano.
 
-{comentario arriba se podría añadir: la `hipótesis de Sapir-Whorf <https://en.wikipedia.org/wiki/Linguistic_relativity>`, que estudia cómo la estructura del lenguaje afecta a la visión que tenemos del mundo}
+{comment arriba se podría añadir: la `hipótesis de Sapir-Whorf <https://en.wikipedia.org/wiki/Linguistic_relativity>`, que estudia cómo la estructura del lenguaje afecta a la visión que tenemos del mundo}
 
 ## Lecturas adicionales
 
@@ -35,7 +35,7 @@ Existen muchas más leyes, observaciones y directrices sobre el diseño de inter
 - Un [glosario de términos de usabilidad](http://www.usabilityfirst.com/glossary/)
 
 - Aquí puedes ver una serie de vídeos cómicos que muestran cómo se verían algunos de los errores típicos de las compras en línea si ocurrieran en la vida real.
-    
+
     - [Google Analytics In Real Life - Site Search](https://www.youtube.com/watch?v=cbtf1oyNg-8)
     - [Google Analytics In Real Life - Online Checkout](https://www.youtube.com/watch?v=3Sk7cOqB9Dk)
     - [Google Analytics In Real Life - Landing Page Optimization](https://www.youtube.com/watch?v=N5WurXNec7E)


### PR DESCRIPTION
Comments that should not be shown are being shown to users due to a Verto tag being translated. In future all comment strings needs to be disabled on Crowdin.

Fixes #969 