### PR TITLE
Fix 2 broken links.

### DIFF
--- a/csfieldguide/chapters/content/en/computer-graphics/sections/further-reading.md
+++ b/csfieldguide/chapters/content/en/computer-graphics/sections/further-reading.md
@@ -2,8 +2,8 @@
 
 ## Useful links
 
-- [https://en.wikipedia.org/wiki/Computer_graphics](https://en.wikipedia.org/wiki/Computer_graphics)
-- [https://en.wikipedia.org/wiki/Transformation_matrix](https://en.wikipedia.org/wiki/Transformation_matrix)
-- [https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm)
-- [https://en.wikipedia.org/wiki/Ray_trace](https://en.wikipedia.org/wiki/Ray_trace)
-- [http://www.povray.org/resources/links/3D_Tutorials/POV-Ray_Tutorials/](http://www.povray.org/resources/links/3D_Tutorials/POV-Ray_Tutorials/)
+- [Computer graphics on Wikipedia](https://en.wikipedia.org/wiki/Computer_graphics)
+- [Transformation matrix on Wikipedia](https://en.wikipedia.org/wiki/Transformation_matrix)
+- [Bresenham's line algorithm on Wikipedia](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm)
+- [Ray tracing on Wikipedia](https://en.wikipedia.org/wiki/Ray_tracing_(graphics))
+- [3D tutorials from POV-Ray](http://www.povray.org/resources/links/3D_Tutorials/POV-Ray_Tutorials/)

--- a/csfieldguide/chapters/content/en/computer-graphics/sections/further-reading.md
+++ b/csfieldguide/chapters/content/en/computer-graphics/sections/further-reading.md
@@ -4,6 +4,6 @@
 
 - [https://en.wikipedia.org/wiki/Computer_graphics](https://en.wikipedia.org/wiki/Computer_graphics)
 - [https://en.wikipedia.org/wiki/Transformation_matrix](https://en.wikipedia.org/wiki/Transformation_matrix)
-- [https://en.wikipedia.org/wiki/Bresenham’s_line_algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm)
+- [https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm)
 - [https://en.wikipedia.org/wiki/Ray_trace](https://en.wikipedia.org/wiki/Ray_trace)
 - [http://www.povray.org/resources/links/3D_Tutorials/POV-Ray_Tutorials/](http://www.povray.org/resources/links/3D_Tutorials/POV-Ray_Tutorials/)

--- a/csfieldguide/chapters/content/en/formal-languages/sections/grammars-and-parsing.md
+++ b/csfieldguide/chapters/content/en/formal-languages/sections/grammars-and-parsing.md
@@ -6,7 +6,7 @@
 
 Currently the section is only introductory.
 
-There's an introduction to this topic (which dwells more on English grammar) at: [http://ozark.hendrix.edu/~burch/cs/150/reading/grammar/index.html](http://www.cburch.com/cs/150/reading/grammar/index.html). This could be used for class discussion.
+There's an introduction to this topic (which dwells more on English grammar) at: [http://www.cburch.com/cs/150/reading/grammar/index.html](http://www.cburch.com/cs/150/reading/grammar/index.html). This could be used for class discussion.
 
 As preparation for reading this chapter, you could do the "planet ABBA" activity with the students as a class, as it will get them familiar with the notation.
 

--- a/csfieldguide/chapters/content/en/formal-languages/sections/grammars-and-parsing.md
+++ b/csfieldguide/chapters/content/en/formal-languages/sections/grammars-and-parsing.md
@@ -6,7 +6,7 @@
 
 Currently the section is only introductory.
 
-There's an introduction to this topic (which dwells more on English grammar) at: [http://www.cburch.com/cs/150/reading/grammar/index.html](http://www.cburch.com/cs/150/reading/grammar/index.html). This could be used for class discussion.
+There's an introduction to this topic (which dwells more on English grammar) at Dr. Carl Burch's [foundations of computer science website](http://www.cburch.com/cs/150/reading/grammar/index.html). This could be used for class discussion.
 
 As preparation for reading this chapter, you could do the "planet ABBA" activity with the students as a class, as it will get them familiar with the notation.
 


### PR DESCRIPTION
Relates to #781 

Does not resolve as https://csfieldguide.org.nz should be fixed with 3.0 release. Linkie was picking up the names for the links as real links so I changed them to something more human readable.