### PR TITLE
Add link to documentation from appendices

### DIFF
--- a/csfieldguide/templates/appendices/index.html
+++ b/csfieldguide/templates/appendices/index.html
@@ -18,6 +18,11 @@
       </a>
     </li>
     <li>
+      <a href="https://cs-field-guide.readthedocs.io/en/latest/index.html">
+        {% trans "Documentation" %}
+      </a>
+    </li>
+    <li>
       <a href="https://cs-field-guide.readthedocs.io/en/latest/changelog.html">
         {% trans "Changelog" %}
       </a>


### PR DESCRIPTION
Links to https://cs-field-guide.readthedocs.io/en/latest/index.html from the appendices