### PR TITLE
Fix binary cards not flipping back to white on chrome

### DIFF
--- a/csfieldguide/static/interactives/binary-cards/css/binary-cards.scss
+++ b/csfieldguide/static/interactives/binary-cards/css/binary-cards.scss
@@ -23,7 +23,9 @@
   border: 1px solid #000000;
   text-align: center;
   box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
-  backface-visibility: hidden;
+  @supports (-moz-appearance: none) {
+    backface-visibility: hidden;
+  }
 }
 #interactive-binary-cards-container div.binary-card canvas {
   margin: 0;


### PR DESCRIPTION
Resolves #1056 
Adds a rule so that the `backface-visibility: hidden;` css rule only applies in firefox (the issue this rule solved, numbers being visible when the card is flipped, does not appear to be an issue on chrome)