### PR TITLE
URL redirects

### DIFF
--- a/csfieldguide/chapters/urls.py
+++ b/csfieldguide/chapters/urls.py
@@ -40,7 +40,7 @@ urlpatterns = [
     # eg: redirect /chapters/index.html to /chapters/
     url(
         r"^index.html$",
-        RedirectView.as_view(permanent=True, url="/chapters/"),
+        RedirectView.as_view(permanent=True, pattern_name="chapters:index"),
     ),
     # eg: redirect /chapters/algorithms.html to /chapters/algorithms/
     url(
@@ -50,6 +50,6 @@ urlpatterns = [
     # eg: redirect /chapters/algorithms.html#searching to /chapters/algorithms/searching/
     url(
         r"^(?P<chapter_slug>[-\w]+).html#(?P<chapter_section_slug>[-\w]+)$",
-        RedirectView.as_view(permanent=True, pattern_name="chapters:chapter:chapter_section"),
+        RedirectView.as_view(permanent=True, pattern_name="chapters:chapter_section"),
     ),
 ]

--- a/csfieldguide/chapters/urls.py
+++ b/csfieldguide/chapters/urls.py
@@ -47,9 +47,4 @@ urlpatterns = [
         r"^(?P<chapter_slug>[-\w]+).html$",
         RedirectView.as_view(permanent=True, pattern_name="chapters:chapter"),
     ),
-    # eg: redirect /chapters/algorithms.html#searching to /chapters/algorithms/searching/
-    url(
-        r"^(?P<chapter_slug>[-\w]+).html#(?P<chapter_section_slug>[-\w]+)$",
-        RedirectView.as_view(permanent=True, pattern_name="chapters:chapter_section"),
-    ),
 ]

--- a/csfieldguide/curriculum_guides/urls.py
+++ b/csfieldguide/curriculum_guides/urls.py
@@ -40,10 +40,4 @@ urlpatterns = [
         r"^(?P<curriculum_guide_slug>[-\w]+)/index.html$",
         RedirectView.as_view(permanent=True, pattern_name="curriculum_guides:curriculum_guide"),
     ),
-    # eg: redirect /curriculum-guides/apcsp/index.html#abstraction to /curriculum-guides/apcsp/abstraction/
-    url(
-        r"^(?P<curriculum_guide_slug>[-\w]+)/index.html#(?P<curriculum_guide_section_slug>[-\w]+)$",
-        RedirectView.as_view(permanent=True,
-                             pattern_name="curriculum_guides:curriculum_guide_section"),
-    ),
 ]

--- a/csfieldguide/general/urls.py
+++ b/csfieldguide/general/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import url
 from . import views
 from django.views.generic.base import RedirectView
 
-
+app_name = "general"
 urlpatterns = [
     # e.g. csfieldguide.org.nz/
     url(
@@ -41,5 +41,9 @@ urlpatterns = [
     url(
         r"^further-information/releases.html$",
         RedirectView.as_view(permanent=True, url="https://cs-field-guide.readthedocs.io/en/latest/changelog.html"),
+    ),
+    url(
+        r"^index.html$",
+        RedirectView.as_view(permanent=True, pattern_name="general:index"),
     ),
 ]


### PR DESCRIPTION
This PR redirects https://csfieldguide.org.nz/index.html to https://csfieldguide.org.nz/ and tidies some code in the `urls.py` files.

~~HELP WANTED:~~

- Currently the redirects for permalinks are incorrect. For example `/chapters/algorithms.html#searching` should redirect to `/chapters/algorithms/searching/` but instead it redirects to `http://localhost:81/en/chapters/algorithms/#searching`.

- Here are the two redirects I found that do not work:
In `chapters/urls.py`:
```
    # eg: redirect /chapters/algorithms.html#searching to /chapters/algorithms/searching/
    url(
        r"^(?P<chapter_slug>[-\w]+).html#(?P<chapter_section_slug>[-\w]+)$",
        RedirectView.as_view(permanent=True, pattern_name="chapters:chapter_section"),
    ),
```
In `curriculum_guides/urls.py`:
```
    # eg: redirect /curriculum-guides/apcsp/index.html#abstraction to /curriculum-guides/apcsp/abstraction/
    url(
        r"^(?P<curriculum_guide_slug>[-\w]+)/index.html#(?P<curriculum_guide_section_slug>[-\w]+)$",
        RedirectView.as_view(permanent=True,
                             pattern_name="curriculum_guides:curriculum_guide_section"),
    ),
```

I tried overriding the `get_url_redirect` method in `views.py` but the code would never get hit? Not sure what's going on and don't seem to be getting very far with it.