### PR TITLE
Add background to navigation dropdown.

### DIFF
--- a/csfieldguide/static/scss/website.scss
+++ b/csfieldguide/static/scss/website.scss
@@ -310,7 +310,7 @@ a {
     background-clip: padding-box;
     border-radius: 0.25rem;
     &.collapsing, &.show {
-      &.teacher-mode-collapsed {
+      &.teacher-mode-collapse {
         background: linear-gradient(to right, #2a3da0 0%, #f44336 65%);
       }
     }

--- a/csfieldguide/static/scss/website.scss
+++ b/csfieldguide/static/scss/website.scss
@@ -304,7 +304,7 @@ a {
 }
 
 // Standard bootstrap-defined Medium devices boundary
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .navbar-collapse {
     background: #2a3da0;
     background-clip: padding-box;

--- a/csfieldguide/static/scss/website.scss
+++ b/csfieldguide/static/scss/website.scss
@@ -302,3 +302,31 @@ a {
     color: #212529;
   }
 }
+
+// Standard bootstrap-defined Medium devices boundary
+@media (max-width: 768px) {
+  .navbar-collapse {
+    background: #2a3da0;
+    background-clip: padding-box;
+    border-radius: 0.25rem;
+    &.collapsing {
+      &.teacher-mode-collapsed {
+        background: linear-gradient(to right, #2a3da0 0%, #f44336 65%);
+      }
+    }
+    &.show {
+      &.teacher-mode-collapsed {
+        background: linear-gradient(to right, #2a3da0 0%, #f44336 65%);
+      }
+    }
+    .nav-item {
+      color: #ffffff !important;
+      padding-left: 1rem !important;
+    }
+  }
+
+  #search-navbar {
+    margin: 5px;
+    width: inherit !important;
+  }
+}

--- a/csfieldguide/static/scss/website.scss
+++ b/csfieldguide/static/scss/website.scss
@@ -309,12 +309,7 @@ a {
     background: #2a3da0;
     background-clip: padding-box;
     border-radius: 0.25rem;
-    &.collapsing {
-      &.teacher-mode-collapsed {
-        background: linear-gradient(to right, #2a3da0 0%, #f44336 65%);
-      }
-    }
-    &.show {
+    &.collapsing, &.show {
       &.teacher-mode-collapsed {
         background: linear-gradient(to right, #2a3da0 0%, #f44336 65%);
       }

--- a/csfieldguide/templates/base.html
+++ b/csfieldguide/templates/base.html
@@ -70,7 +70,7 @@
                 </a>
               </div>
             </div>
-            <div class="collapse navbar-collapse" id="navbarNav">
+            <div class="collapse navbar-collapse{% if teacher_mode %} teacher-mode-collapsed{% endif %}" id="navbarNav">
               <div class="navbar-nav navbar-nav-i18n mr-auto">
                 <a class="nav-item nav-link" href="{% url 'chapters:index' %}">
                   {% trans "Chapters" %}

--- a/csfieldguide/templates/base.html
+++ b/csfieldguide/templates/base.html
@@ -70,7 +70,7 @@
                 </a>
               </div>
             </div>
-            <div class="collapse navbar-collapse{% if teacher_mode %} teacher-mode-collapsed{% endif %}" id="navbarNav">
+            <div class="collapse navbar-collapse{% if teacher_mode %} teacher-mode-collapse{% endif %}" id="navbarNav">
               <div class="navbar-nav navbar-nav-i18n mr-auto">
                 <a class="nav-item nav-link" href="{% url 'chapters:index' %}">
                   {% trans "Chapters" %}


### PR DESCRIPTION
Adds blue background to dropdown navigation when in student mode and gradient background when in teacher mode. See below:

![image](https://user-images.githubusercontent.com/16066822/60409029-c8e1d380-9c15-11e9-8f93-eca4290001d6.png)

![image](https://user-images.githubusercontent.com/16066822/60409042-d6975900-9c15-11e9-93ad-2a405df1f360.png)

Relates to #1054. Does not resolve as there is a comment on this issue regarding scrolling but I cannot test it on desktop.