### PR TITLE
Add reshuffle weights button to Sorting Algorithms interactive

### DIFF
--- a/csfieldguide/static/interactives/sorting-algorithms/js/sorting-algorithms.js
+++ b/csfieldguide/static/interactives/sorting-algorithms/js/sorting-algorithms.js
@@ -69,6 +69,9 @@ $(function() {
     $('#reset-button').on('click', function () {
         reset();
     });
+    $('#reshuffle-button').on('click', function () {
+        reshuffle();
+    });
 });
 
 /**
@@ -229,4 +232,19 @@ function reset() {
     var s = interpolate(fmts, {comparisons: comparisons}, true);
     document.getElementById('comparison-counter-text').innerText = s;
     $('#check-order-result-text-feedback').html('<br>');
+}
+
+/**
+ * Returns all images to their original locations, weights reshuffled, and resets
+ * the number of comparisons made
+ */
+function reshuffle() {
+    reset();
+
+    var images_to_sort = document.getElementsByClassName('sorting-boxes');
+    var shuffled_weights = shuffle(data_weights);
+    for (var i = 0; i < images_to_sort.length; i++) {
+        var image = images_to_sort[i];
+        image.dataset.weight = shuffled_weights[i];
+    }
 }

--- a/csfieldguide/templates/interactives/sorting-algorithms.html
+++ b/csfieldguide/templates/interactives/sorting-algorithms.html
@@ -88,9 +88,12 @@
         <div id="check-order-result-text-feedback" class="h5">
           <br>
         </div>
-        <div class="mb3">
+        <div class="mb-1">
           <button class="btn btn-primary" type="button" id="check-sorted-button">{% trans "Check Order" %}</button>
-          <button class="btn btn-danger" type="button" id="reset-button">{% trans "Reset" %}</button>
+          <button class="btn btn-warning" type="button" id="reset-button">{% trans "Reset" %}</button>
+        </div>
+        <div class="mb-1">
+          <button class="btn btn-danger" type="button" id="reshuffle-button">{% trans "Reshuffle weights" %}</button>
         </div>
         <p id="comparison-counter-text"></p>
         <button class="btn btn-secondary btn-sm" type="button" id="toggle-second-row"></button>


### PR DESCRIPTION
This PR is not important

Adds a 'Reshuffle weights' button to the sorting algorithms interactive.
This button resets the interactive *with new weight values* so that a subsequent sort doesn't give the same result. Also makes it more clear (implies) that the existing 'reset' button does not reshuffle the weights