### PR TITLE
Reduce length of search bar on mobile

### DIFF
--- a/csfieldguide/templates/base.html
+++ b/csfieldguide/templates/base.html
@@ -83,8 +83,8 @@
                 </a>
               </div>
               {% if LANGUAGE_CODE == "en" %}
-                <!-- Search is only currently available in English -->
-                <form method="get" action="{% url 'search:index' %}">
+                <!-- Search is currently only available in English -->
+                <form class="form-inline" method="get" action="{% url 'search:index' %}">
                   <div class="input-group" id="search-navbar">
                     <input type="search" class="form-control form-control-sm border-0" placeholder="{% trans "Search" %}" aria-label="Search" name="q" required="required">
                     <div class="input-group-append">


### PR DESCRIPTION
Adds the class `form-inline` to the homepage search bar so that it isn't overly long on mobile screens