### PR TITLE
Add link to Vox video in computer vision chapter.

### DIFF
--- a/csfieldguide/chapters/content/en/computer-vision/sections/face-recognition.md
+++ b/csfieldguide/chapters/content/en/computer-vision/sections/face-recognition.md
@@ -12,6 +12,7 @@ It can also be useful for privacy — Google Maps streetview identifies faces an
 Digital cameras can find faces in a scene and use them to adjust the focus and lighting.
 
 There is some information about [how facial recognition works](http://electronics.howstuffworks.com/gadgets/high-tech-gadgets/facial-recognition.htm) that you can read up as background, and some more information at [i-programmer.info](http://www.i-programmer.info/babbages-bag/1091-face-recognition.html).
+If you're interested, there is also a Vox video on [how snapchat filters work](https://www.youtube.com/watch?v=Pc2aJxnmzh0) that mentions facial recognition algorithms.
 
 There are some relevant [articles on the cs4fn website](http://www.cs4fn.org/vision/) that also provide some general material on computer vision.
 


### PR DESCRIPTION
Resolves #367. Was kind of hard to mention nicely in the text since we dump a whole bunch of links in this section. Should be better once #409 is completed.