### PR TITLE
Amend content licence to exclude certain properties we don't own

### DIFF
--- a/LICENCE-CONTENT
+++ b/LICENCE-CONTENT
@@ -5,6 +5,18 @@ This license applies to the following contents of this project:
 - Markdown files located within the `csfieldguide/chapters/content/` directory.
 - Images located within the `csfieldguide/static/img/` directory.
 
+With the following exceptions:
+
+- Images located within the `csfieldguide/static/img/chapters/` directory that
+  are prefixed with `xkcd` are the property of Randall Munroe and licensed under
+  a Creative Commons Attribution-NonCommercial 2.5 License.
+- Images located within the `csfieldguide/static/img/third-party/` directory
+  are used with permission from their respective owners and may be subject to their
+  own licenses.
+- Images located within the `csfieldguide/static/img/logos/` directory
+  are the properties of the companies depicted and may be subject to their
+  own licenses.
+
 =======================================================================
 
 Creative Commons Corporation ("Creative Commons") is not a law firm and

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ to get started.
 The content of this project itself is licensed under the
 [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) license](https://creativecommons.org/licenses/by-sa/4.0/)
 (`LICENCE-CONTENT` file).
-This license applies to the following contents of this project:
+This license applies to the following contents of this project, with
+exceptions listed in the `LICENCE-CONTENT` file:
 
 - Markdown files located within the `csfieldguide/chapters/content/` directory.
 - Images located within the `csfieldguide/static/img/` directory.
 
-Third-party libraries used in this project have their license's
+Third-party libraries used in this project have their licenses
 listed within the `LICENCE-THIRD-PARTY` file, with a full copy of the license
 available within the `third-party-licences` directory.
 If a source file of a third-party library or system is stored within this


### PR DESCRIPTION
Amends the LICENCE-CONTENT file to exclude:

- Images located within the `csfieldguide/static/img/chapters/` directory that are prefixed with `xkcd`
- `csfieldguide/static/img/third-party/`
- `csfieldguide/static/img/logos/`

as they may be subject to different licences