### PR TITLE
Fix consistency in RSA interactives

### DIFF
--- a/csfieldguide/static/interactives/rsa-decryption/js/rsa-decryption.js
+++ b/csfieldguide/static/interactives/rsa-decryption/js/rsa-decryption.js
@@ -342,7 +342,7 @@ function decrypt() {
     Key = new nodeRSA();
     var components = {};
     if (isPublicKey) {
-      components.e = parseInt($('#rsa-decryption-key-e').val().trim(), 16),
+      components.e = parseInt($('#rsa-decryption-key-e').val().trim().split(' ').join('').toLowerCase(), 16),
       components.n = $('#rsa-decryption-key-n').val().trim().split(' ').join('').toLowerCase();
       try {
         Key.importKey({

--- a/csfieldguide/static/interactives/rsa-encryption/js/rsa-encryption.js
+++ b/csfieldguide/static/interactives/rsa-encryption/js/rsa-encryption.js
@@ -342,7 +342,7 @@ function encrypt() {
     Key = new nodeRSA();
     var components = {};
     if (isPublicKey) {
-      components.e = parseInt($('#rsa-encryption-key-e').val().trim(), 16),
+      components.e = parseInt($('#rsa-encryption-key-e').val().trim().split(' ').join('').toLowerCase(), 16),
       components.n = $('#rsa-encryption-key-n').val().trim().split(' ').join('').toLowerCase();
       try {
         Key.importKey({
@@ -483,6 +483,9 @@ function libraryEncrypt() {
   }
 }
 
+/**
+ * Copies the ciphertext to user's clipboard
+ */
 function copy() {
   $('#rsa-encryption-ciphertext').select();
   try {

--- a/csfieldguide/static/interactives/rsa-key-generator/js/rsa-key-generator.js
+++ b/csfieldguide/static/interactives/rsa-key-generator/js/rsa-key-generator.js
@@ -139,6 +139,5 @@ function parseHexString(number) {
   for (var i=0; i < chars.length; i+=2) {
     pairs.push(chars[i] + chars[i + 1]);
   }
-  console.log(pairs);
   return pairs.join(" ");
 }

--- a/csfieldguide/static/interactives/rsa-key-generator/js/rsa-key-generator.js
+++ b/csfieldguide/static/interactives/rsa-key-generator/js/rsa-key-generator.js
@@ -83,7 +83,7 @@ $(document).ready(function() {
  */
 function formatPublicComponents(components) {
   var returnText = "e:\n"
-                 + parseHex([components.e]) + "\n\n"
+                 + parseHexString(components.e) + "\n\n"
                  + "n:\n"
                  + parseHex(components.n);
 
@@ -108,7 +108,7 @@ function formatPrivateComponents(components) {
 
 /**
  * Parses each item in the given list,
- * creating a space-separated string of hexadecimal representations
+ * creating a space-separated string of hexadecimal representations; in groups of two
  */
 function parseHex(list) {
   var length = list.length;
@@ -123,4 +123,22 @@ function parseHex(list) {
     returnString += char + " ";
   }
   return returnString.toUpperCase();
+}
+
+/**
+ * Creates a space-separated string of hexadecimal representations; in groups of two
+ */
+function parseHexString(number) {
+  var n = number.toString(16);
+  if (n.length % 2 != 0) {
+    n = "0" + n; // Add leading 0 to make even
+  }
+  // Split into pairs
+  var chars = n.split('');
+  var pairs = [];
+  for (var i=0; i < chars.length; i+=2) {
+    pairs.push(chars[i] + chars[i + 1]);
+  }
+  console.log(pairs);
+  return pairs.join(" ");
 }

--- a/csfieldguide/templates/interactives/rsa-decryption.html
+++ b/csfieldguide/templates/interactives/rsa-decryption.html
@@ -47,7 +47,7 @@
                 <form>
                   <div class="form-group">
                     <label for="rsa-decryption-key-e">e:</label>
-                    <input id="rsa-decryption-key-e" type="text" class="form-control" placeholder="10001">
+                    <input id="rsa-decryption-key-e" type="text" class="form-control" placeholder="01 00 01">
                   </div>
 
                   <div class="form-group">

--- a/csfieldguide/templates/interactives/rsa-encryption.html
+++ b/csfieldguide/templates/interactives/rsa-encryption.html
@@ -55,7 +55,7 @@
                 <form>
                   <div class="form-group">
                     <label for="rsa-encryption-key-e">e:</label>
-                    <input id="rsa-encryption-key-e" type="text" class="form-control" placeholder="10001">
+                    <input id="rsa-encryption-key-e" type="text" class="form-control" placeholder="01 00 01">
                   </div>
 
                   <div class="form-group">

--- a/csfieldguide/templates/interactives/rsa-key-generator.html
+++ b/csfieldguide/templates/interactives/rsa-key-generator.html
@@ -40,7 +40,7 @@
 
         <div class="row text-left">
           <div class="col-12">
-            <p><em>{% trans "<strong>Warning:</strong> Keys larger than 512 bits may take longer than a second to create." %}</em></p>
+            <p class="text-muted"><em>{% trans "<strong>Warning:</strong> Keys larger than 512 bits may take longer than a second to create." %}</em></p>
           </div>
         </div>
 


### PR DESCRIPTION
Implements a fix I was meant to do in #1123 

The `e` component of keys is now split into pairs of characters (bytes) for consistency