### PR TITLE
Exclude licences directory from Linkie

### DIFF
--- a/.arnold.yaml
+++ b/.arnold.yaml
@@ -43,6 +43,7 @@ broken-link-checker:
   exclude-directories:
     - .git/
     - docs/build/
+    - third-party-licences/
   skip-urls:
     # Intentional broken links
     - https://www.google.com/teapot


### PR DESCRIPTION
Adds the `third-party-licences` directory to the list of directories Linkie will not run over when checking for broken links. We cannot change licences to fix/remove broken links so instead we can whitelist them so they do not appear as errors

Relates to #1153