### PR TITLE
Set crossorigin attribute on the default image in pixel viewer

### DIFF
--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -60,7 +60,7 @@ $( document ).ready(function() {
     var image_filename = 'coloured-roof-small.png';
   }
   var image_filepath = image_base_path + image_filename;
-  document.getElementById('pixel-viewer-interactive-original-image').setAttribute('src', image_filepath);
+  $('#pixel-viewer-interactive-original-image').attr('crossorigin', 'anonymous').attr('src', image_filepath);
   load_resize_image(image_filepath, false);
 
   if (getUrlParameter('mode') == 'threshold') {
@@ -827,12 +827,13 @@ function createPicturePicker(){
   main_div.append($("<p></p>").text(gettext("Or choose from the following supplied images:")));
   for (var i = 0; i < images.length; i++){
     var img_url = image_base_path + images[i]
-    img = document.createElement("IMG");
-    img.setAttribute('crossorigin', 'anonymous')
-    img.setAttribute('src', img_url)
-    img.setAttribute('class', 'img-pick')
-    img.onclick = function(){load_resize_image(this.src, false);}
-    main_div.append(img);
+    main_div.append(
+      $("<img>")
+      .attr('crossorigin', 'anonymous')
+      .attr('src', img_url)
+      .attr('class', 'img-pick')
+      .click(function(){load_resize_image(this.src, false);})
+    );
   }
 }
 

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -60,7 +60,8 @@ $( document ).ready(function() {
     var image_filename = 'coloured-roof-small.png';
   }
   var image_filepath = image_base_path + image_filename;
-  $('#pixel-viewer-interactive-original-image').attr('src', image_filepath);
+  // $('#pixel-viewer-interactive-original-image').attr('src', image_filepath);
+  document.getElementById('pixel-viewer-interactive-original-image').setAttribute('src', image_filepath);
   load_resize_image(image_filepath, false);
 
   if (getUrlParameter('mode') == 'threshold') {
@@ -827,13 +828,19 @@ function createPicturePicker(){
   main_div.append($("<p></p>").text(gettext("Or choose from the following supplied images:")));
   for (var i = 0; i < images.length; i++){
     var img_url = image_base_path + images[i]
-    main_div.append(
-      $("<img>")
-      .attr('crossorigin', 'anonymous')
-      .attr('src', img_url)
-      .attr('class', 'img-pick')
-      .click(function(){load_resize_image(this.src, false);})
-    );
+    img = document.createElement("IMG");
+    img.setAttribute('crossorigin', 'anonymous')
+    img.setAttribute('src', img_url)
+    img.setAttribute('class', 'img-pick')
+    img.onclick = function(){load_resize_image(this.src, false);}
+    main_div.append(img);
+    // main_div.append(
+    //   $("<img>")
+    //   .attr('crossorigin', 'anonymous')
+    //   .attr('src', img_url)
+    //   .attr('class', 'img-pick')
+    //   .click(function(){load_resize_image(this.src, false);})
+    // );
   }
 }
 

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -60,7 +60,6 @@ $( document ).ready(function() {
     var image_filename = 'coloured-roof-small.png';
   }
   var image_filepath = image_base_path + image_filename;
-  // $('#pixel-viewer-interactive-original-image').attr('src', image_filepath);
   document.getElementById('pixel-viewer-interactive-original-image').setAttribute('src', image_filepath);
   load_resize_image(image_filepath, false);
 
@@ -834,13 +833,6 @@ function createPicturePicker(){
     img.setAttribute('class', 'img-pick')
     img.onclick = function(){load_resize_image(this.src, false);}
     main_div.append(img);
-    // main_div.append(
-    //   $("<img>")
-    //   .attr('crossorigin', 'anonymous')
-    //   .attr('src', img_url)
-    //   .attr('class', 'img-pick')
-    //   .click(function(){load_resize_image(this.src, false);})
-    // );
   }
 }
 


### PR DESCRIPTION
Inconsistencies have been occurring on the pixel viewer interactive regarding CORS requests. After some investigating we noticed:

- Upon disabling cache through dev tools we no longer got a CORS error.
- Two requests for images were being made; one of which was being made through jquery.
- In the response headers there is an attribute `sec-fetch-mode` that has the value `no-cors`.
- Only the default image was triggering the CORS error.

We suspect that the jquery request is being cached first (which doesn't have CORS headers), and then the second request is made (with CORS headers) but during this request Chrome fetches from the cache (but the CORS headers aren't cached due to the first request) which results in a CORS error on the second fetch.

With this change we see only one request being made and it appears to have the `sec-fetch-mode` attribute set to `cors` locally.