### PR TITLE
Allow users to choose the number of cards displayed in binary cards interactive with input box

### DIFF
--- a/csfieldguide/chapters/content/en/data-representation/sections/whats-the-big-picture.md
+++ b/csfieldguide/chapters/content/en/data-representation/sections/whats-the-big-picture.md
@@ -11,7 +11,7 @@ Now click on the previous card, which should have two dots on it.
 Before clicking on the next one, how many dots do you predict it will have?
 Carry on clicking on each card moving left, trying to guess how many dots each has.
 
-{interactive slug="binary-cards" type="whole-page" text="Binary Cards" parameters="digits=5&start=BBBBB&dropdown=false"}
+{interactive slug="binary-cards" type="whole-page" text="Binary Cards" parameters="digits=5&start=BBBBB&input=false"}
 
 The challenge for you now is to find a way to have exactly 22 dots showing
 (the answer is in the spoiler below).

--- a/csfieldguide/chapters/content/en/data-representation/sections/whats-the-big-picture.md
+++ b/csfieldguide/chapters/content/en/data-representation/sections/whats-the-big-picture.md
@@ -11,7 +11,7 @@ Now click on the previous card, which should have two dots on it.
 Before clicking on the next one, how many dots do you predict it will have?
 Carry on clicking on each card moving left, trying to guess how many dots each has.
 
-{interactive slug="binary-cards" type="whole-page" text="Binary Cards" parameters="digits=5&start=BBBBB"}
+{interactive slug="binary-cards" type="whole-page" text="Binary Cards" parameters="digits=5&start=BBBBB&dropdown=false"}
 
 The challenge for you now is to find a way to have exactly 22 dots showing
 (the answer is in the spoiler below).

--- a/csfieldguide/chapters/content/en/data-representation/sections/whats-the-big-picture.md
+++ b/csfieldguide/chapters/content/en/data-representation/sections/whats-the-big-picture.md
@@ -11,7 +11,7 @@ Now click on the previous card, which should have two dots on it.
 Before clicking on the next one, how many dots do you predict it will have?
 Carry on clicking on each card moving left, trying to guess how many dots each has.
 
-{interactive slug="binary-cards" type="whole-page" text="Binary Cards" parameters="digits=5&start=BBBBB&input=false"}
+{interactive slug="binary-cards" type="whole-page" text="Binary Cards" parameters="cards=5&start=BBBBB&input=false"}
 
 The challenge for you now is to find a way to have exactly 22 dots showing
 (the answer is in the spoiler below).

--- a/csfieldguide/static/interactives/binary-cards/README.md
+++ b/csfieldguide/static/interactives/binary-cards/README.md
@@ -10,16 +10,16 @@ This interactive is created to teach binary numbers, and emulates the Binary Car
 The interactive shows the cards with dots from **128** to **1** by default (128, 64, 32, 16, 8, 4, 2, 1), however these can be configured by the following parameters:
 
 - `base=value` - Where `value` is the number base to use (defaults as 2).
-- `digits=value` - Where `value` is the amount of digits to display (default is 8). Min is 1 and max is 16.
-- `offset=value` - Where `value` is the amount to offset the displayed digits (default is 0). Using a positive number will show the placings from the `digits` + `offset` value, for the number of given digits. For example, using a base of `10`, digits as `3`, and offset as `2` will show the 100,000, 10,000, 1,000, and 100 placings. Using a negative number for the `value` will display floating numbers.
-- `start=sides` - Where `sides` is a sequence of `W` and `B` characters, to state the sides that should be displayed when the interactive starts. The first letter states whether the first card (on the left) should be white (`W`) or black (`B`), the second letter stands for the second card. Therefore the number of letters should match the number of digits used.
+- `cards=value` - Where `value` is the number of cards to display (default is 8). Min is 1 and max is 16.
+- `offset=value` - Where `value` is the amount to offset the displayed cards (default is 0). Using a positive number will show the placings from the `cards` + `offset` value, for the number of given cards. For example, using a base of `10`, cards as `3`, and offset as `2` will show the 100,000, 10,000, 1,000, and 100 placings. Using a negative number for the `value` will display floating numbers.
+- `start=sides` - Where `sides` is a sequence of `W` and `B` characters, to state the sides that should be displayed when the interactive starts. The first letter states whether the first card (on the left) should be white (`W`) or black (`B`), the second letter stands for the second card. Therefore the number of letters should match the number of cards used.
 - `input=value` - Where `value` is `true` or `false` (default is true). Indicates whether or not to display the input box that lets users choose how many cards are displayed.
 
 ### Examples
 
-- `?base=16&digits=4` - Shows 6 (default) cards for the first 4 digits of base 16 (hexadecimal).
-- `?digits=4&offset=-2` - Shows 5 cards for the 4 digits of base 2 (binary), starting with the second digit and showing the next four (the 0.5 and 0.25 places).
-- `?digits=5&start=BBBBB` - Shows 5 cards for the 5 digits of base 2 (binary), with all sides showing black to start.
+- `?base=16&cards=4` - Shows the first 4 cards of base 16 (hexadecimal).
+- `?cards=4&offset=-2` - Shows 4 cards of base 2 (binary). 2, 1, 0.5 and 0.25.
+- `?cards=5&start=BBBBB` - Shows 5 cards of base 2 (binary), with all sides showing black to start.
 
 To use these parameters, the interactive must be used in either `whole-page` or `iframe` mode.
 

--- a/csfieldguide/static/interactives/binary-cards/README.md
+++ b/csfieldguide/static/interactives/binary-cards/README.md
@@ -1,6 +1,7 @@
 # Binary Cards Interactive
 
 **Author:** Jack Morgan
+**Modified by:** Courtney Bracefield
 
 This interactive is created to teach binary numbers, and emulates the Binary Cards CS Unplugged activity.
 
@@ -9,9 +10,10 @@ This interactive is created to teach binary numbers, and emulates the Binary Car
 The interactive shows the cards with dots from **128** to **1** by default (128, 64, 32, 16, 8, 4, 2, 1), however these can be configured by the following parameters:
 
 - `base=value` - Where `value` is the number base to use (defaults as 2).
-- `digits=value` - Where `value` is the amounts of digits to display (default is 6).
+- `digits=value` - Where `value` is the amount of digits to display (default is 8).
 - `offset=value` - Where `value` is the amount to offset the displayed digits (default is 0). Using a positive number will show the placings from the `digits` + `offset` value, for the number of given digits. For example, using a base of `10`, digits as `3`, and offset as `2` will show the 100,000, 10,000, 1,000, and 100 placings. Using a negative number for the `value` will display floating numbers.
 - `start=sides` - Where `sides` is a sequence of `W` and `B` characters, to state the sides that should be displayed when the interactive starts. The first letter states whether the first card (on the left) should be white (`W`) or black (`B`), the second letter stands for the second card. Therefore the number of letters should match the number of digits used.
+- `dropdown=value` - Where `value` is `true` or `false` (default is true). Indicates whether or not to display the dropdown that lets users choose how many cards are displayed.
 
 ### Examples
 

--- a/csfieldguide/static/interactives/binary-cards/README.md
+++ b/csfieldguide/static/interactives/binary-cards/README.md
@@ -10,10 +10,10 @@ This interactive is created to teach binary numbers, and emulates the Binary Car
 The interactive shows the cards with dots from **128** to **1** by default (128, 64, 32, 16, 8, 4, 2, 1), however these can be configured by the following parameters:
 
 - `base=value` - Where `value` is the number base to use (defaults as 2).
-- `digits=value` - Where `value` is the amount of digits to display (default is 8).
+- `digits=value` - Where `value` is the amount of digits to display (default is 8). Min is 1 and max is 16.
 - `offset=value` - Where `value` is the amount to offset the displayed digits (default is 0). Using a positive number will show the placings from the `digits` + `offset` value, for the number of given digits. For example, using a base of `10`, digits as `3`, and offset as `2` will show the 100,000, 10,000, 1,000, and 100 placings. Using a negative number for the `value` will display floating numbers.
 - `start=sides` - Where `sides` is a sequence of `W` and `B` characters, to state the sides that should be displayed when the interactive starts. The first letter states whether the first card (on the left) should be white (`W`) or black (`B`), the second letter stands for the second card. Therefore the number of letters should match the number of digits used.
-- `dropdown=value` - Where `value` is `true` or `false` (default is true). Indicates whether or not to display the dropdown that lets users choose how many cards are displayed.
+- `input=value` - Where `value` is `true` or `false` (default is true). Indicates whether or not to display the input box that lets users choose how many cards are displayed.
 
 ### Examples
 

--- a/csfieldguide/static/interactives/binary-cards/README.md
+++ b/csfieldguide/static/interactives/binary-cards/README.md
@@ -20,6 +20,8 @@ The interactive shows the cards with dots from **128** to **1** by default (128,
 - `?base=16&cards=4` - Shows the first 4 cards of base 16 (hexadecimal).
 - `?cards=4&offset=-2` - Shows 4 cards of base 2 (binary). 2, 1, 0.5 and 0.25.
 - `?cards=5&start=BBBBB` - Shows 5 cards of base 2 (binary), with all sides showing black to start.
+- `?cards=2&start=BBBBB` - Here the number of cards is less than the length of the start parameter. The cards parameter will always take precedence, therefore 2 cards with sides with their sides set to black will be shown to start. The next 3 hidden cards will also have their sides set to black.
+- `?cards=4&start=BB` - Here the number of cards is more than the length of the start parameter. The cards parameter will always take precedence, therefore 4 cards will be displayed, with their sides set to WWBB.
 
 To use these parameters, the interactive must be used in either `whole-page` or `iframe` mode.
 

--- a/csfieldguide/static/interactives/binary-cards/css/binary-cards.scss
+++ b/csfieldguide/static/interactives/binary-cards/css/binary-cards.scss
@@ -73,3 +73,11 @@
 h3, h5, p {
   text-align: left;
 }
+// Hide arrows in input box on some browsers as it's jumpy
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    margin: 0;
+}

--- a/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
+++ b/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
@@ -7,10 +7,10 @@ $(document).ready(function () {
     // Settings for interactive
     // Since users can possibly choose the num of cards from an input box,
     // we first load the max possible num of cards so it is easy to hide and re display cards.
-    // URL parameter for digits is checked after initial 16 cards have loaded.
+    // URL parameter for cards is checked after initial 16 cards have loaded.
     var binaryValueSettings = {
         BASE: Number(urlParameters.getUrlParameter('base')) || 2,
-        DIGITS: MAX_NUM_CARDS,
+        CARDS: MAX_NUM_CARDS,
         OFFSET: Number(urlParameters.getUrlParameter('offset')) || 0,
         INPUT: urlParameters.getUrlParameter('input') || 'true',
     }
@@ -40,39 +40,39 @@ $(document).ready(function () {
 
     // Update number of cards shown based on input
     $('input').change(function() {
-        binaryValueSettings.DIGITS = $('input')[1].value;
-        putDigitsWithinLimits(binaryValueSettings.DIGITS, showInputBox, binaryValueSettings);
-        updateCards(binaryValueSettings.DIGITS);
+        binaryValueSettings.CARDS = $('input')[1].value;
+        putCardsWithinLimits(binaryValueSettings.CARDS, showInputBox, binaryValueSettings);
+        updateCards(binaryValueSettings.CARDS);
         updateDotCount();
     });
 
     // Create cards within container and update count
     createCards(binaryValueSettings);
     // Check if digit URL parameter was given and hide appropriate cards if so
-    if (Number(urlParameters.getUrlParameter('digits'))) {
-        digits = Number(urlParameters.getUrlParameter('digits'));
-        putDigitsWithinLimits(digits, showInputBox, binaryValueSettings);
-        updateCards(binaryValueSettings.DIGITS);
+    if (Number(urlParameters.getUrlParameter('cards'))) {
+        cards = Number(urlParameters.getUrlParameter('cards'));
+        putCardsWithinLimits(cards, showInputBox, binaryValueSettings);
+        updateCards(binaryValueSettings.CARDS);
     } else {
         // Show default number of cards
-        binaryValueSettings.DIGITS = DEFAULT_NUM_CARDS_TO_SHOW;
-        updateCards(binaryValueSettings.DIGITS);
+        binaryValueSettings.CARDS = DEFAULT_NUM_CARDS_TO_SHOW;
+        updateCards(binaryValueSettings.CARDS);
     }
     updateDotCount();
 });
 
 
-// Ensure digits value is between 1 and MAX_NUM_CARDS
-function putDigitsWithinLimits(digits, showInputBox, binaryValueSettings) {
-    if (digits > MAX_NUM_CARDS) {
-        binaryValueSettings.DIGITS = MAX_NUM_CARDS;
-    } else if (digits < 1) {
-        binaryValueSettings.DIGITS = 1;
+// Ensure cards value is between 1 and MAX_NUM_CARDS
+function putCardsWithinLimits(cards, showInputBox, binaryValueSettings) {
+    if (cards > MAX_NUM_CARDS) {
+        binaryValueSettings.CARDS = MAX_NUM_CARDS;
+    } else if (cards < 1) {
+        binaryValueSettings.CARDS = 1;
     } else {
-        binaryValueSettings.DIGITS = digits;
+        binaryValueSettings.CARDS = cards;
     }
     if (showInputBox) {
-        $('input')[1].value = binaryValueSettings.DIGITS;
+        $('input')[1].value = binaryValueSettings.CARDS;
     }
 }
 
@@ -81,7 +81,7 @@ function putDigitsWithinLimits(digits, showInputBox, binaryValueSettings) {
 function createCards(settings) {
     var cardContainer = $('#interactive-binary-cards-container');
 
-    var value = Math.pow(settings.BASE, settings.DIGITS + settings.OFFSET - 1);
+    var value = Math.pow(settings.BASE, settings.CARDS + settings.OFFSET - 1);
     var starting_sides = urlParameters.getUrlParameter('start') || "";
     // Since we always load max num of cards to begin with we should pad the `start` URL parameter
     // if it contains less than max num values.
@@ -91,7 +91,7 @@ function createCards(settings) {
     }
 
     // Iterate through card values
-    for (var digit = 0; digit < settings.DIGITS; digit++) {
+    for (var digit = 0; digit < settings.CARDS; digit++) {
         cardContainer.append(createCard(value, starting_sides[digit] == 'B'));
         value /= settings.BASE;
     }

--- a/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
+++ b/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
@@ -41,14 +41,7 @@ $(document).ready(function () {
     // Update number of cards shown based on input
     $('input').change(function() {
         binaryValueSettings.DIGITS = $('input')[1].value;
-        if (binaryValueSettings.DIGITS > 16) {
-            console.log(binaryValueSettings.DIGITS);
-            binaryValueSettings.DIGITS = 16;
-            $('input')[1].value = 16;
-        } else if (binaryValueSettings.DIGITS < 1) {
-            binaryValueSettings.DIGITS = 1;
-            $('input')[1].value = 1;
-        }
+        putDigitsWithinLimits(binaryValueSettings.DIGITS, showInputBox, binaryValueSettings);
         updateCards(binaryValueSettings.DIGITS);
         updateDotCount();
     });
@@ -58,13 +51,7 @@ $(document).ready(function () {
     // Check if digit URL parameter was given and hide appropriate cards if so
     if (Number(urlParameters.getUrlParameter('digits'))) {
         digits = Number(urlParameters.getUrlParameter('digits'));
-        if (digits > 16) {
-            digits = 16;
-        } else if (digits < 1) {
-            digits = 1;
-        }
-        binaryValueSettings.DIGITS = digits;
-        $('input')[1].value = binaryValueSettings.DIGITS;
+        putDigitsWithinLimits(digits, showInputBox, binaryValueSettings);
         updateCards(binaryValueSettings.DIGITS);
     } else {
         // Show default number of cards
@@ -73,6 +60,21 @@ $(document).ready(function () {
     }
     updateDotCount();
 });
+
+
+// Ensure digits value is between 1 and MAX_NUM_CARDS
+function putDigitsWithinLimits(digits, showInputBox, binaryValueSettings) {
+    if (digits > MAX_NUM_CARDS) {
+        binaryValueSettings.DIGITS = MAX_NUM_CARDS;
+    } else if (digits < 1) {
+        binaryValueSettings.DIGITS = 1;
+    } else {
+        binaryValueSettings.DIGITS = digits;
+    }
+    if (showInputBox) {
+        $('input')[1].value = binaryValueSettings.DIGITS;
+    }
+}
 
 
 // Sets up the cards for the interactive

--- a/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
+++ b/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
@@ -42,6 +42,7 @@ $(document).ready(function () {
     $('input').change(function() {
         binaryValueSettings.DIGITS = $('input')[1].value;
         if (binaryValueSettings.DIGITS > 16) {
+            console.log(binaryValueSettings.DIGITS);
             binaryValueSettings.DIGITS = 16;
             $('input')[1].value = 16;
         } else if (binaryValueSettings.DIGITS < 1) {
@@ -57,9 +58,14 @@ $(document).ready(function () {
     // Check if digit URL parameter was given and hide appropriate cards if so
     if (Number(urlParameters.getUrlParameter('digits'))) {
         digits = Number(urlParameters.getUrlParameter('digits'));
+        if (digits > 16) {
+            digits = 16;
+        } else if (digits < 1) {
+            digits = 1;
+        }
         binaryValueSettings.DIGITS = digits;
-        $('input')[1].value = digits;
-        updateCards(digits);
+        $('input')[1].value = binaryValueSettings.DIGITS;
+        updateCards(binaryValueSettings.DIGITS);
     } else {
         // Show default number of cards
         binaryValueSettings.DIGITS = DEFAULT_NUM_CARDS_TO_SHOW;

--- a/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
+++ b/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
@@ -3,10 +3,20 @@ var urlParameters = require('../../../js/third-party/url-parameters.js')
 
 $(document).ready(function () {
     // Settings for interactive
+    // Since users can possibly select num of cards from a dropdown,
+    // we first load all of the cards so it is easy to hide and re display cards.
+    // URL parameter for digits is checked after initial 8 cards have loaded.
     var binaryValueSettings = {
         BASE: Number(urlParameters.getUrlParameter('base')) || 2,
-        DIGITS: Number(urlParameters.getUrlParameter('digits')) || 8,
-        OFFSET: Number(urlParameters.getUrlParameter('offset')) || 0
+        DIGITS: 8,
+        OFFSET: Number(urlParameters.getUrlParameter('offset')) || 0,
+        DROPDOWN: urlParameters.getUrlParameter('dropdown') || 'true',
+    }
+
+    var showDropdown = (binaryValueSettings.DROPDOWN == 'true');
+    // Don't display the dropdown
+    if (!showDropdown) {
+        $("#cards-dropdown").addClass('d-none');
     }
 
     $('#interactive-binary-cards').on('click', '.binary-card', function(event) {
@@ -26,8 +36,22 @@ $(document).ready(function () {
         updateDotCount();
     });
 
+    // Update number of cards shown based on dropdown choice
+    $('select').change(function() {
+        binaryValueSettings.DIGITS = $("select option:selected").val();
+        updateCards(binaryValueSettings.DIGITS);
+        updateDotCount();
+    });
+
     // Create cards within container and update count
     createCards(binaryValueSettings);
+    // Check if digit URL parameter was given and hide appropriate cards if so
+    if (Number(urlParameters.getUrlParameter('digits'))) {
+        digits = Number(urlParameters.getUrlParameter('digits'));
+        binaryValueSettings.DIGITS = digits;
+        $("select").find('option[value=' + digits + ']').prop('selected', true);
+        updateCards(digits);
+    }
     updateDotCount();
 });
 
@@ -38,6 +62,12 @@ function createCards(settings) {
 
     var value = Math.pow(settings.BASE, settings.DIGITS + settings.OFFSET - 1);
     var starting_sides = urlParameters.getUrlParameter('start') || "";
+    // Since we always load 8 cards to begin with we should pad the `start` URL parameter
+    // if it contains less than 8 values.
+    if (starting_sides != "" && starting_sides.length < 8) {
+        var padding_length = 8 - starting_sides.length;
+        starting_sides = "W" * padding_length + starting_sides;
+    }
 
     // Iterate through card values
     for (var digit = 0; digit < settings.DIGITS; digit++) {
@@ -49,7 +79,7 @@ function createCards(settings) {
 
 // Returns the HTML for a card for a given value
 function createCard(value, is_black) {
-    var cardContainer = $("<div class='binary-card-container'></div>");
+    var cardContainer = $("<div class='binary-card-container visible'></div>");
     var card = $("<div class='binary-card'></div>");
     cardContainer.append(card);
     var front = $("<div class='binary-card-side binary-card-front'></div>");
@@ -165,7 +195,7 @@ function updateDotCount() {
     var dotCount = 0;
     $('#interactive-binary-cards-container').children().each(function(cardPosition, card) {
         var card = $(card.children[0]);
-        if (!card.hasClass('flipped')) {
+        if (!card.hasClass('flipped') && !card.parent().hasClass('d-none')) {
             dotCount += card.data("value");
         }
     });
@@ -175,3 +205,37 @@ function updateDotCount() {
     var dotCountText = interpolate(format, {"dot_count": dotCount}, true);
     dotText.html(dotCountText);
 };
+
+
+// Change the number of cards shown
+function updateCards(num_cards_to_show) {
+    // mapping of card to child number in DOM tree
+    // 8th card (2^8) is the first child, 7th card (2^7) is the second and so on..
+    var card_num_to_child_num = {
+        8: 1,
+        7: 2,
+        6: 3,
+        5: 4,
+        4: 5,
+        3: 6,
+        2: 7,
+        1: 8,
+    };
+    num_current_cards_shown = $('#interactive-binary-cards-container div.visible').length;
+    difference = Math.abs(num_current_cards_shown - num_cards_to_show);
+    if (num_current_cards_shown > num_cards_to_show) {
+        // hide cards
+        for (i=0; i<difference; i++) {
+            child_num = card_num_to_child_num[num_current_cards_shown - i]
+            element = $('#interactive-binary-cards-container > div:nth-child(' + child_num + ')');
+            element.removeClass('visible').addClass('d-none');
+        }
+    } else if (num_current_cards_shown < num_cards_to_show) {
+        // show more cards
+        for (i=1; i<=difference; i++) {
+            child_num = card_num_to_child_num[num_current_cards_shown + i]
+            element = $('#interactive-binary-cards-container > div:nth-child(' + child_num + ')');
+            element.removeClass('d-none').addClass('visible');
+        }
+    }
+}

--- a/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
+++ b/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
@@ -1,14 +1,16 @@
 var urlParameters = require('../../../js/third-party/url-parameters.js')
 "use strict";
+MAX_NUM_CARDS = 16;
+DEFAULT_NUM_CARDS_TO_SHOW = 8;
 
 $(document).ready(function () {
     // Settings for interactive
     // Since users can possibly select num of cards from a dropdown,
-    // we first load all of the cards so it is easy to hide and re display cards.
-    // URL parameter for digits is checked after initial 8 cards have loaded.
+    // we first load the max possible num of cards so it is easy to hide and re display cards.
+    // URL parameter for digits is checked after initial 16 cards have loaded.
     var binaryValueSettings = {
         BASE: Number(urlParameters.getUrlParameter('base')) || 2,
-        DIGITS: 8,
+        DIGITS: MAX_NUM_CARDS,
         OFFSET: Number(urlParameters.getUrlParameter('offset')) || 0,
         DROPDOWN: urlParameters.getUrlParameter('dropdown') || 'true',
     }
@@ -16,7 +18,7 @@ $(document).ready(function () {
     var showDropdown = (binaryValueSettings.DROPDOWN == 'true');
     // Don't display the dropdown
     if (!showDropdown) {
-        $("#cards-dropdown").addClass('d-none');
+        $("#cards-input").addClass('d-none');
     }
 
     $('#interactive-binary-cards').on('click', '.binary-card', function(event) {
@@ -36,9 +38,16 @@ $(document).ready(function () {
         updateDotCount();
     });
 
-    // Update number of cards shown based on dropdown choice
-    $('select').change(function() {
-        binaryValueSettings.DIGITS = $("select option:selected").val();
+    // Update number of cards shown based on input
+    $('input').change(function() {
+        binaryValueSettings.DIGITS = $('input')[1].value;
+        if (binaryValueSettings.DIGITS > 16) {
+            binaryValueSettings.DIGITS = 16;
+            $('input')[1].value = 16;
+        } else if (binaryValueSettings.DIGITS < 1) {
+            binaryValueSettings.DIGITS = 1;
+            $('input')[1].value = 1;
+        }
         updateCards(binaryValueSettings.DIGITS);
         updateDotCount();
     });
@@ -49,8 +58,12 @@ $(document).ready(function () {
     if (Number(urlParameters.getUrlParameter('digits'))) {
         digits = Number(urlParameters.getUrlParameter('digits'));
         binaryValueSettings.DIGITS = digits;
-        $("select").find('option[value=' + digits + ']').prop('selected', true);
+        $('input')[1].value = digits;
         updateCards(digits);
+    } else {
+        // Show default number of cards
+        binaryValueSettings.DIGITS = DEFAULT_NUM_CARDS_TO_SHOW;
+        updateCards(binaryValueSettings.DIGITS);
     }
     updateDotCount();
 });
@@ -62,11 +75,11 @@ function createCards(settings) {
 
     var value = Math.pow(settings.BASE, settings.DIGITS + settings.OFFSET - 1);
     var starting_sides = urlParameters.getUrlParameter('start') || "";
-    // Since we always load 8 cards to begin with we should pad the `start` URL parameter
-    // if it contains less than 8 values.
-    if (starting_sides != "" && starting_sides.length < 8) {
-        var padding_length = 8 - starting_sides.length;
-        starting_sides = "W" * padding_length + starting_sides;
+    // Since we always load max num of cards to begin with we should pad the `start` URL parameter
+    // if it contains less than max num values.
+    if (starting_sides != "" && starting_sides.length < MAX_NUM_CARDS) {
+        var padding_length = MAX_NUM_CARDS - starting_sides.length;
+        starting_sides = "W".repeat(padding_length) + starting_sides;
     }
 
     // Iterate through card values
@@ -210,16 +223,24 @@ function updateDotCount() {
 // Change the number of cards shown
 function updateCards(num_cards_to_show) {
     // mapping of card to child number in DOM tree
-    // 8th card (2^8) is the first child, 7th card (2^7) is the second and so on..
+    // 16th card (2^15) is the first child, 15th card (2^14) is the second and so on..
     var card_num_to_child_num = {
-        8: 1,
-        7: 2,
-        6: 3,
-        5: 4,
-        4: 5,
-        3: 6,
-        2: 7,
-        1: 8,
+        16: 1,
+        15: 2,
+        14: 3,
+        13: 4,
+        12: 5,
+        11: 6,
+        10: 7,
+        9: 8,
+        8: 9,
+        7: 10,
+        6: 11,
+        5: 12,
+        4: 13,
+        3: 14,
+        2: 15,
+        1: 16,
     };
     num_current_cards_shown = $('#interactive-binary-cards-container div.visible').length;
     difference = Math.abs(num_current_cards_shown - num_cards_to_show);

--- a/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
+++ b/csfieldguide/static/interactives/binary-cards/js/binary-cards.js
@@ -5,19 +5,19 @@ DEFAULT_NUM_CARDS_TO_SHOW = 8;
 
 $(document).ready(function () {
     // Settings for interactive
-    // Since users can possibly select num of cards from a dropdown,
+    // Since users can possibly choose the num of cards from an input box,
     // we first load the max possible num of cards so it is easy to hide and re display cards.
     // URL parameter for digits is checked after initial 16 cards have loaded.
     var binaryValueSettings = {
         BASE: Number(urlParameters.getUrlParameter('base')) || 2,
         DIGITS: MAX_NUM_CARDS,
         OFFSET: Number(urlParameters.getUrlParameter('offset')) || 0,
-        DROPDOWN: urlParameters.getUrlParameter('dropdown') || 'true',
+        INPUT: urlParameters.getUrlParameter('input') || 'true',
     }
 
-    var showDropdown = (binaryValueSettings.DROPDOWN == 'true');
-    // Don't display the dropdown
-    if (!showDropdown) {
+    var showInputBox = (binaryValueSettings.INPUT == 'true');
+    // Don't display the input box
+    if (!showInputBox) {
         $("#cards-input").addClass('d-none');
     }
 

--- a/csfieldguide/templates/interactives/binary-cards.html
+++ b/csfieldguide/templates/interactives/binary-cards.html
@@ -18,18 +18,9 @@
             <button id="flip-to-black" class="btn btn-dark">{% trans "Black" %}</button>
             <button id="flip-to-white" class="btn btn-light">{% trans "White" %}</button>
           </div>
-          <div id="cards-dropdown" class="form-group form-inline">
-            <label for="cards-to-show" class="mr-2">{% trans "Select how many cards to show:" %}</label>
-            <select id="cards-to-show" class="form-control">
-              <option value=1>1</option>
-              <option value=2>2</option>
-              <option value=3>3</option>
-              <option value=4>4</option>
-              <option value=5>5</option>
-              <option value=6>6</option>
-              <option value=7>7</option>
-              <option value=8 selected>8</option>
-            </select>
+          <div id="cards-input" class="form-group form-inline">
+            <label for="cards-to-show" class="mr-2">{% trans "Choose how many cards to show:" %}</label>
+            <input id="cards-to-show" class="form-control" type="number" min="1" max="16" value="8"/>
           </div>
         </div>
       </div>

--- a/csfieldguide/templates/interactives/binary-cards.html
+++ b/csfieldguide/templates/interactives/binary-cards.html
@@ -18,17 +18,17 @@
             <button id="flip-to-black" class="btn btn-dark">{% trans "Black" %}</button>
             <button id="flip-to-white" class="btn btn-light">{% trans "White" %}</button>
           </div>
-          <div class="form-group form-inline">
+          <div id="cards-dropdown" class="form-group form-inline">
             <label for="cards-to-show" class="mr-2">{% trans "Select how many cards to show:" %}</label>
-            <select class="form-control" id="cards-to-show">
-              <option>1</option>
-              <option>2</option>
-              <option>3</option>
-              <option>4</option>
-              <option>5</option>
-              <option>6</option>
-              <option>7</option>
-              <option>8</option>
+            <select id="cards-to-show" class="form-control">
+              <option value=1>1</option>
+              <option value=2>2</option>
+              <option value=3>3</option>
+              <option value=4>4</option>
+              <option value=5>5</option>
+              <option value=6>6</option>
+              <option value=7>7</option>
+              <option value=8 selected>8</option>
             </select>
           </div>
         </div>

--- a/csfieldguide/templates/interactives/binary-cards.html
+++ b/csfieldguide/templates/interactives/binary-cards.html
@@ -13,11 +13,24 @@
           <div id="interactive-binary-cards-container" class="my-2"></div>
           <h5 id="dot-decimal-count"></h5>
 
-          <p>
-            {% trans "Flip all card sides to:" %}
+          <div class="mb-2">
+            <p class="d-inline mr-2">{% trans "Flip all card sides to:" %}</p>
             <button id="flip-to-black" class="btn btn-dark">{% trans "Black" %}</button>
             <button id="flip-to-white" class="btn btn-light">{% trans "White" %}</button>
-          </p>
+          </div>
+          <div class="form-group form-inline">
+            <label for="cards-to-show" class="mr-2">{% trans "Select how many cards to show:" %}</label>
+            <select class="form-control" id="cards-to-show">
+              <option>1</option>
+              <option>2</option>
+              <option>3</option>
+              <option>4</option>
+              <option>5</option>
+              <option>6</option>
+              <option>7</option>
+              <option>8</option>
+            </select>
+          </div>
         </div>
       </div>
     </div>

--- a/csfieldguide/templates/interactives/binary-cards.html
+++ b/csfieldguide/templates/interactives/binary-cards.html
@@ -19,8 +19,8 @@
             <button id="flip-to-white" class="btn btn-light">{% trans "White" %}</button>
           </div>
           <div id="cards-input" class="form-group form-inline">
-            <label for="cards-to-show" class="mr-2">{% trans "Choose how many cards to show:" %}</label>
-            <input id="cards-to-show" class="form-control" type="number" min="1" max="16" value="8"/>
+            <label for="cards-to-show" class="mr-2">{% trans "Cards to show:" %}</label>
+            <input id="cards-to-show" class="form-control col-md-1 col-4" type="number" min="1" max="16" value="8"/>
           </div>
         </div>
       </div>


### PR DESCRIPTION
**Changes**

- Add input box to the binary cards interactive that allows the user to change how many cards are displayed. This can be anywhere from 1 to 16 cards inclusive.

- Add `input` URL parameter. Can be set to either 'true' or 'false to show or hide the input box respectively. Default is set to 'true'.

**Notes**

- The interactive now loads 16 (the max) cards first, before hiding cards to show the default 8 cards (or the value of the `digits` URL parameter if it is passed). Mostly done to prevent rewriting majority of the code. This allows us to easily hide and show cards dynamically when the user interacts with the input box.

- If a `start` parameter is passed that is less than 16 (or whatever the max is set to) letters long, e.g `BBBBB` we add padding to the start of the string so that the correct cards are flipped to the correct side. E.g `BBBBB` would become `WWWWWWWWWWWBBBBB`. This is not shown in the URL.

- When the numbers get large they overflow the cards but this currently happens on prod. I have created an issue for this.

Resolves #1262 
