### PR TITLE
Fix issue with LZSS compression interactive encoding text incorrectly

### DIFF
--- a/csfieldguide/chapters/content/en/coding-compression/sections/general-purpose.md
+++ b/csfieldguide/chapters/content/en/coding-compression/sections/general-purpose.md
@@ -13,7 +13,7 @@ The interactive below illustrates this idea using a variation of the Ziv-Lempel 
 
 In LZSS, a reference to where some text occurred before is actually two numbers: the first says how many characters to count back to where the previous phrase starts, and the second says how long the referenced phrase is.
 Each reference typically takes the space of about one or two characters, so the system makes a saving as long as two characters are replaced.
-The options in the interactive above allow you to require the replaced length to be at least two characters, to avoid replacing a single character with a reference.
+The interactive above requires the replaced length to be at least two characters, this avoids replacing a single character with a reference.
 Of course, all characters count, not just letters of the alphabet, so the system can also refer back to the spaces between words.
 In fact, some of the most common sequences are things like a full stop followed by a space.
 

--- a/csfieldguide/chapters/content/en/coding-compression/sections/general-purpose.md
+++ b/csfieldguide/chapters/content/en/coding-compression/sections/general-purpose.md
@@ -13,7 +13,6 @@ The interactive below illustrates this idea using a variation of the Ziv-Lempel 
 
 In LZSS, a reference to where some text occurred before is actually two numbers: the first says how many characters to count back to where the previous phrase starts, and the second says how long the referenced phrase is.
 Each reference typically takes the space of about one or two characters, so the system makes a saving as long as two characters are replaced.
-The interactive above requires the replaced length to be at least two characters, this avoids replacing a single character with a reference.
 Of course, all characters count, not just letters of the alphabet, so the system can also refer back to the spaces between words.
 In fact, some of the most common sequences are things like a full stop followed by a space.
 

--- a/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
+++ b/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
@@ -184,14 +184,13 @@ function compressText(message) {
     }
 
     // initialise sliding window and initial encoded message
-    sliding_window = message.slice(0, 1);
-    encoded_message = message.slice(0, 1);
+    sliding_window = message.slice(0, min_match_length);
+    encoded_message = message.slice(0, min_match_length);
 
-    message.splice(0, 1);
+    message.splice(0, min_match_length);
 
     // read in string to length of max match
     string_to_match = message.splice(0, max_match_length);
-    console.log('string to match: ' + string_to_match);
     while (true) {
         if (string_to_match.length > 0) {
 
@@ -204,7 +203,6 @@ function compressText(message) {
             for (var i = 0; i < sliding_window.length; i++) {
                 // get next character in sliding window
                 sw_character = sliding_window[i];
-                console.log('sw_char: ' + sw_character);
 
                 if (string_to_match[0] == 'null') { // meaning is newline character
                     // add newline character to sliding window and remove from message
@@ -240,9 +238,6 @@ function compressText(message) {
                             break;
                         }
                     }
-                    console.log('next sw char: ' + next_sw_character);
-                    console.log('next search char: ' + next_search_character);
-                    console.log('curr length of match: ' + current_length_of_match);
 
                     // work out if best match so far
                     if (current_length_of_match > longest_match_length) {
@@ -277,8 +272,6 @@ function compressText(message) {
                     }
                 }
             }
-            console.log('sliding window: ' + sliding_window);
-            console.log('string to match: ' + string_to_match);
 
         } else {
             break;

--- a/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
+++ b/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
@@ -3,7 +3,7 @@ var string_to_match;
 var num_characters = 1;
 // set the min and max match length
 var min_match_length = 2;
-var max_match_length = 7;
+var max_match_length = 16;
 var encoded_message = [];
 var start_index;
 var end_index;
@@ -15,14 +15,14 @@ Some like it in the pot, nine days old.`);
 
 // Set placeholder message
 window.onload = function() {
-    var message_div = document.getElementById('message-to-decode');
+    var message_div = document.getElementById('message-to-encode');
     message_div.value = placeholder_message;
     document.getElementById('lzss-compression-compress-button').addEventListener('click', compress, false);  
 }
 
 // Compress the message and display the encoded message
 function compress() {
-    var message = document.getElementById('message-to-decode').value;
+    var message = document.getElementById('message-to-encode').value;
     // clear any existed encoded message
     document.getElementById('lzss-compression-compressed-text').innerHTML = '';
     compressText(message);
@@ -181,6 +181,7 @@ function compressText(message) {
 
     for (var i = 0; i < message.length; i++) {
         message[i] = message[i].replace(/[\r\n]+/g, null);
+        message[i] = message[i].replace(/[\s]+/g, "\u2423");
     }
 
     // initialise sliding window and initial encoded message

--- a/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
+++ b/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
@@ -191,7 +191,7 @@ function compressText(message) {
 
     // read in string to length of max match
     string_to_match = message.splice(0, max_match_length);
-
+    console.log('string to match: ' + string_to_match);
     while (true) {
         if (string_to_match.length > 0) {
 
@@ -204,6 +204,7 @@ function compressText(message) {
             for (var i = 0; i < sliding_window.length; i++) {
                 // get next character in sliding window
                 sw_character = sliding_window[i];
+                console.log('sw_char: ' + sw_character);
 
                 if (string_to_match[0] == 'null') { // meaning is newline character
                     // add newline character to sliding window and remove from message
@@ -239,6 +240,9 @@ function compressText(message) {
                             break;
                         }
                     }
+                    console.log('next sw char: ' + next_sw_character);
+                    console.log('next search char: ' + next_search_character);
+                    console.log('curr length of match: ' + current_length_of_match);
 
                     // work out if best match so far
                     if (current_length_of_match > longest_match_length) {
@@ -273,6 +277,8 @@ function compressText(message) {
                     }
                 }
             }
+            console.log('sliding window: ' + sliding_window);
+            console.log('string to match: ' + string_to_match);
 
         } else {
             break;

--- a/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
+++ b/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
@@ -3,7 +3,7 @@ var string_to_match;
 var num_characters = 1;
 // set the min and max match length
 var min_match_length = 2;
-var max_match_length = 5;
+var max_match_length = 7;
 var encoded_message = [];
 var start_index;
 var end_index;

--- a/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
+++ b/csfieldguide/static/interactives/lzss-compression/js/lzss-compression.js
@@ -184,10 +184,10 @@ function compressText(message) {
     }
 
     // initialise sliding window and initial encoded message
-    sliding_window = message.slice(0, 6);
-    encoded_message = message.slice(0, 6);
+    sliding_window = message.slice(0, 1);
+    encoded_message = message.slice(0, 1);
 
-    message.splice(0, 6);
+    message.splice(0, 1);
 
     // read in string to length of max match
     string_to_match = message.splice(0, max_match_length);

--- a/csfieldguide/static/interactives/lzss-compression/scss/lzss-compression.scss
+++ b/csfieldguide/static/interactives/lzss-compression/scss/lzss-compression.scss
@@ -71,6 +71,16 @@ body {
     }
 }
 
+#message-to-encode {
+    font: 1rem "Courier New", monospace;
+    font-size: 1.2rem;
+}
+
+#char-replacement-note {
+    font-size: 0.8rem;
+    color: grey;
+}
+
 .highlight {
     outline: 2px solid #85c1dd;
     outline-offset: 0.5px;

--- a/csfieldguide/templates/interactives/lzss-compression.html
+++ b/csfieldguide/templates/interactives/lzss-compression.html
@@ -11,7 +11,7 @@
         <div id="lzss-compression-left-box">
           <p>{% trans "Enter the message you want to encode here" %}:</p>
           <div id="lzss-compression-input-text">
-            <textarea class="form-control" rows="5" id="message-to-decode"></textarea>
+            <textarea class="form-control" rows="5" id="message-to-encode"></textarea>
           </div>
           <div>
             <button id="lzss-compression-compress-button" class="btn btn-primary btn-block" type="button">
@@ -21,8 +21,8 @@
         </div>
         <div id="lzss-compression-right-box">
           <p>{% trans "Encoded Message" %}:</p>
-          <div id="lzss-compression-compressed-text">
-          </div>
+          <div id="lzss-compression-compressed-text"></div>
+          <p id="char-replacement-note">{% trans "Note: spaces have been replaced with the &#9251; character." %}</p>
         </div>
       </div>
     </div>

--- a/csfieldguide/templates/interactives/lzss-compression.html
+++ b/csfieldguide/templates/interactives/lzss-compression.html
@@ -22,7 +22,7 @@
         <div id="lzss-compression-right-box">
           <p>{% trans "Encoded Message" %}:</p>
           <div id="lzss-compression-compressed-text"></div>
-          <p id="char-replacement-note">{% trans "Note: spaces have been replaced with the &#9251; character." %}</p>
+          <p id="char-replacement-note">{% trans "Note: spaces are replaced with the &#9251; character." %}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR addresses a bug in the LZSS interactive where the text is not being encoded correctly for some strings.

**The problem** 
The sliding window and encoded message are initialised to the first 6 characters. This means the first 6 characters can never be pointers - even if there are repeating strings within these 6 characters. This does not work correctly for small strings or for strings of a repeating nature, e.g `ababababababab`.

**Changes**

- Initialise sliding window and encoded message to only contain the first 2 characters (minimum match length).
- Raise max length of match to 16 (4 bits). This used to be 5 which is unusually small.
- Replace space characters in the encoded message with the open box character. This addresses part of #1253
- Add small note under the encoded text stating that spaces are replaced with the open box character.

Resolves #1271