### PR TITLE
Add ability to show colour codes in Hexadecimal on Pixel Viewer

### DIFF
--- a/csfieldguide/static/interactives/pixel-viewer/README.md
+++ b/csfieldguide/static/interactives/pixel-viewer/README.md
@@ -18,6 +18,11 @@ The interactive has the following parameters to configure the interactive:
   - `blur` - Adds controls for investigating blurring with images.
   - `edgedetection` - Adds controls for investigating edge detection.
 
+- `colour-code=type` (optional) - Where `type` is one of the following:
+
+  - `rgb` (default) - Shows the colour of the pixel in RGB format.
+  - `hex` - Shows the colour of the pixel in Hexadecimal format.
+
 - `image` (optional) - Filename of image to use (for example `arnold.jpg`).
 - `picturepicker` (optional) - Displays a set of pictures available for using.
 - `hide-menu` (optional) - Hides the menu.

--- a/csfieldguide/static/interactives/pixel-viewer/README.md
+++ b/csfieldguide/static/interactives/pixel-viewer/README.md
@@ -20,7 +20,8 @@ The interactive has the following parameters to configure the interactive:
 
 - `colour-code=type` (optional) - Where `type` is one of the following:
 
-  - `rgb` (default) - Shows the colour of the pixel in RGB format.
+  - `rgb` (default) - Shows the colour of the pixel in RGB format using Decimal.
+  - `rgb-hex` - Shows the colour of the pixel in RGB format using Hexadecimal.
   - `hex` - Shows the colour of the pixel in Hexadecimal format.
 
 - `image` (optional) - Filename of image to use (for example `arnold.jpg`).

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -48,6 +48,8 @@ this.images = [
 this.tiling = new Tiling;
 this.piccache = Array();
 
+var show_hex = true
+
 const image_base_path = base_static_path + 'interactives/pixel-viewer/img/';
 var source_canvas = document.getElementById('pixel-viewer-interactive-source-canvas');
 
@@ -872,6 +874,10 @@ $('#pixel-viewer-interactive-show-pixel-fill').change(function() {
     scroller.finishPullToRefresh();
 });
 
+$("input[name='colourCode']").click(function() {
+    var colour_code = $("input[name='colourCode']:checked").val()
+})
+
 // Caches data about the image
 function init_cache(width, height){
   piccache = Array()
@@ -987,7 +993,6 @@ var paint = function(row, col, left, top, width, height, zoom) {
 
     // If text opacity is greater than 0, then display RGB values
     if (text_opacity > 0) {
-        context.font = (14 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
         if (!show_pixel_fill) {
             context.fillStyle = "rgba(0, 0, 0, " + text_opacity + ")";
         } else if ((((pixelData[0] / 255) + (pixelData[1] / 255) + (pixelData[2] / 255)) / 3) < 0.85) {
@@ -996,13 +1001,34 @@ var paint = function(row, col, left, top, width, height, zoom) {
             context.fillStyle = "rgba(110, 110, 110, " + text_opacity + ")";
         }
 
-        // Pretty primitive text positioning
-        var cell_lines = cell_text.split('\n');
-
-        for (var i = 0; i < cell_lines.length; i++)
-            context.fillText(cell_lines[i] + pixelData[i], left + (6 * zoom), top + (14 * zoom) + (i * cell_line_height * zoom) );
+        if (show_hex) {
+          context.font = (10 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
+          r = pixelData[0];
+          g = pixelData[1];
+          b = pixelData[2];
+          hex_string = rgbToHex(r, g, b);
+          context.fillText(hex_string, left + (4 * zoom), top + (14 * zoom) + (cell_line_height * zoom));
+        } else {
+          context.font = (14 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
+          // Pretty primitive text positioning
+          var cell_lines = cell_text.split('\n');
+          for (var i = 0; i < cell_lines.length; i++) {
+            context.fillText(cell_lines[i] + pixelData[i], left + (6 * zoom), top + (14 * zoom) + (i * cell_line_height * zoom));
+          }
+        }
     }
 };
+
+
+// Taken from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
+function componentToHex(c) {
+  var hex = c.toString(16);
+  return hex.length == 1 ? "0" + hex : hex;
+}
+
+function rgbToHex(r, g, b) {
+  return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+}
 
 var rect = container.getBoundingClientRect();
 scroller.setPosition(rect.left + container.clientLeft, rect.top + container.clientTop);

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -1030,7 +1030,7 @@ var paint = function(row, col, left, top, width, height, zoom) {
           var cell_lines = cell_text.split('\n');
           for (var i = 0; i < cell_lines.length; i++) {
             if (colour_code_rep == 'rgb-hex') { // Shows colour codes in RGB using Hexadecimal
-              value = ' ' + componentToHex(pixelData[i]) // Prefix with space so that the positioning is nice
+              value = componentToHex(pixelData[i])
             } else { // Shows colour codes in RGB using Decimal
               value = pixelData[i]
             }
@@ -1042,7 +1042,7 @@ var paint = function(row, col, left, top, width, height, zoom) {
 
 // Taken from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
 function componentToHex(c) {
-  var hex = c.toString(16);
+  var hex = c.toString(16).toUpperCase();
   return hex.length == 1 ? "0" + hex : hex;
 }
 

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -48,10 +48,9 @@ this.images = [
 this.tiling = new Tiling;
 this.piccache = Array();
 
-var show_hex = true
-
 const image_base_path = base_static_path + 'interactives/pixel-viewer/img/';
 var source_canvas = document.getElementById('pixel-viewer-interactive-source-canvas');
+var show_hex = false
 
 $( document ).ready(function() {
   init_cache(300, MAX_HEIGHT);
@@ -61,6 +60,7 @@ $( document ).ready(function() {
   } else {
     var image_filename = 'coloured-roof-small.png';
   }
+
   var image_filepath = image_base_path + image_filename;
   $('#pixel-viewer-interactive-original-image').attr('crossorigin', 'anonymous').attr('src', image_filepath);
   load_resize_image(image_filepath, false);
@@ -74,17 +74,29 @@ $( document ).ready(function() {
   } else if (getUrlParameter('mode') == 'edgedetection') {
     mode = 'edgedetection';
   }
+
   if (getUrlParameter('picturepicker')){
     // Whether or not to allow student to pick from set pictures
     picturePicker = true;
   }
+
   if (getUrlParameter('hide-menu')) {
     $('#pixel-viewer-interactive-menu-toggle').remove();
   }
+
   setUpMode();
   if (picturePicker){
    createPicturePicker();
   }
+
+  if (getUrlParameter('colour-code') == 'hex') {
+    show_hex = true;
+    $("input[id='hex-colour-code']").prop('checked', true);
+  } else {
+    show_hex = false;
+    $("input[id='rgb-colour-code']").prop('checked', true);
+  }
+
   if (getUrlParameter('no-pixel-fill')){
     $('#pixel-viewer-interactive-show-pixel-fill').prop('checked', false);
     $( "#pixel-viewer-interactive-loader" ).hide();
@@ -876,6 +888,12 @@ $('#pixel-viewer-interactive-show-pixel-fill').change(function() {
 
 $("input[name='colourCode']").click(function() {
     var colour_code = $("input[name='colourCode']:checked").val()
+    if (colour_code == 'hex') {
+      show_hex = true
+    } else {
+      show_hex = false
+    }
+    scroller.finishPullToRefresh();
 })
 
 // Caches data about the image
@@ -1018,7 +1036,6 @@ var paint = function(row, col, left, top, width, height, zoom) {
         }
     }
 };
-
 
 // Taken from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
 function componentToHex(c) {

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -996,7 +996,7 @@ var paint = function(row, col, left, top, width, height, zoom) {
             context.fillStyle = "rgba(110, 110, 110, " + text_opacity + ")";
         }
 
-        // Pretty primitive text positioning :)
+        // Pretty primitive text positioning
         var cell_lines = cell_text.split('\n');
 
         for (var i = 0; i < cell_lines.length; i++)

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -50,7 +50,7 @@ this.piccache = Array();
 
 const image_base_path = base_static_path + 'interactives/pixel-viewer/img/';
 var source_canvas = document.getElementById('pixel-viewer-interactive-source-canvas');
-var show_hex = false
+var colour_code_rep = 'rgb';
 
 $( document ).ready(function() {
   init_cache(300, MAX_HEIGHT);
@@ -89,11 +89,14 @@ $( document ).ready(function() {
    createPicturePicker();
   }
 
-  if (getUrlParameter('colour-code') == 'hex') {
-    show_hex = true;
+  if (getUrlParameter('colour-code') == 'rgb-hex') {
+    colour_code_rep = 'rgb-hex';
+    $("input[id='rgb-hex-colour-code']").prop('checked', true);
+  } else if (getUrlParameter('colour-code') == 'hex') {
+    colour_code_rep = 'hex';
     $("input[id='hex-colour-code']").prop('checked', true);
   } else {
-    show_hex = false;
+    colour_code_rep = 'rgb';
     $("input[id='rgb-colour-code']").prop('checked', true);
   }
 
@@ -887,12 +890,7 @@ $('#pixel-viewer-interactive-show-pixel-fill').change(function() {
 });
 
 $("input[name='colourCode']").click(function() {
-    var colour_code = $("input[name='colourCode']:checked").val()
-    if (colour_code == 'hex') {
-      show_hex = true
-    } else {
-      show_hex = false
-    }
+    colour_code_rep = $("input[name='colourCode']:checked").val()
     scroller.finishPullToRefresh();
 })
 
@@ -1019,7 +1017,8 @@ var paint = function(row, col, left, top, width, height, zoom) {
             context.fillStyle = "rgba(110, 110, 110, " + text_opacity + ")";
         }
 
-        if (show_hex) {
+        // Pretty primitive text positioning
+        if (colour_code_rep == 'hex') { // Shows colour codes in #FFFFFF style
           context.font = (10 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
           r = pixelData[0];
           g = pixelData[1];
@@ -1028,10 +1027,14 @@ var paint = function(row, col, left, top, width, height, zoom) {
           context.fillText(hex_string, left + (4 * zoom), top + (14 * zoom) + (cell_line_height * zoom));
         } else {
           context.font = (14 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
-          // Pretty primitive text positioning
           var cell_lines = cell_text.split('\n');
           for (var i = 0; i < cell_lines.length; i++) {
-            context.fillText(cell_lines[i] + pixelData[i], left + (6 * zoom), top + (14 * zoom) + (i * cell_line_height * zoom));
+            if (colour_code_rep == 'rgb-hex') { // Shows colour codes in RGB using Hexadecimal
+              value = ' ' + componentToHex(pixelData[i]) // Prefix with space so that the positioning is nice
+            } else { // Shows colour codes in RGB using Decimal
+              value = pixelData[i]
+            }
+            context.fillText(cell_lines[i] + value, left + (6 * zoom), top + (14 * zoom) + (i * cell_line_height * zoom));
           }
         }
     }

--- a/csfieldguide/templates/interactives/pixel-viewer.html
+++ b/csfieldguide/templates/interactives/pixel-viewer.html
@@ -30,7 +30,7 @@
                 <p id="pixel-viewer-extra-feature-description"></p>
 
                 <span id="pixel-viewer-image-manipulator"></span>
-                <p>{% trans "This interactive works best on a desktop Chrome browser, due to the heavy performance load." %}</p>
+                <p>{% trans "This interactive works best on a desktop browser, due to the heavy performance load." %}</p>
 
                 <hr>
 
@@ -39,15 +39,15 @@
                     <input id="pixel-viewer-interactive-show-pixel-fill" type="checkbox" checked="checked">
                     {% trans "Show pixel background" %}
                 </label>
-                <div class="mb-1">
+                <div class="btn-group-vertical d-flex mb-1">
                     {% trans "Colour code: " %}
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="colourCode" id="rgb-colour-code" value="rgb" checked>
-                        <label class="form-check-label" for="rgb-colour-code">{% trans "Decimal (as separate RGB values)" %}</label>
+                        <label class="form-check-label" for="rgb-colour-code">{% trans "Decimal (separate RGB)" %}</label>
                     </div>
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="colourCode" value="rgb-hex" id="rgb-hex-colour-code">
-                        <label class="form-check-label" for="rgb-hex-colour-code">{% trans "Hexadecimal (as separate RGB values)" %}</label>
+                        <label class="form-check-label" for="rgb-hex-colour-code">{% trans "Hexadecimal (separate RGB)" %}</label>
                     </div>
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="colourCode" value="hex" id="hex-colour-code">

--- a/csfieldguide/templates/interactives/pixel-viewer.html
+++ b/csfieldguide/templates/interactives/pixel-viewer.html
@@ -43,15 +43,15 @@
                     {% trans "Colour code: " %}
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="colourCode" id="rgb-colour-code" value="rgb" checked>
-                        <label class="form-check-label" for="rgb-colour-code">{% trans "Decimal" %}</label>
+                        <label class="form-check-label" for="rgb-colour-code">{% trans "Decimal (as separate RGB values)" %}</label>
                     </div>
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="colourCode" value="rgb-hex" id="rgb-hex-colour-code">
-                        <label class="form-check-label" for="rgb-hex-colour-code">{% trans "Hexadecimal" %}</label>
+                        <label class="form-check-label" for="rgb-hex-colour-code">{% trans "Hexadecimal (as separate RGB values)" %}</label>
                     </div>
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="colourCode" value="hex" id="hex-colour-code">
-                        <label class="form-check-label" for="hex-colour-code">{% trans "Web colour" %}</label>
+                        <label class="form-check-label" for="hex-colour-code">{% trans "Hexadecimal (web colour)" %}</label>
                     </div>
                 </div>
                 <div class="dropdown">

--- a/csfieldguide/templates/interactives/pixel-viewer.html
+++ b/csfieldguide/templates/interactives/pixel-viewer.html
@@ -39,6 +39,17 @@
                     <input id="pixel-viewer-interactive-show-pixel-fill" type="checkbox" checked="checked">
                     {% trans "Show pixel background" %}
                 </label>
+                <div class="mb-1">
+                    {% trans "Colour code: " %}
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" name="colourCode" id="rgb-colour-code" value="rgb" checked>
+                        <label class="form-check-label" for="rgb-colour-code">{% trans "RGB" %}</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" name="colourCode" value="hex" id="hex-colour-code">
+                        <label class="form-check-label" for="hex-colour-code">{% trans "Hexadecimal" %}</label>
+                    </div>
+                </div>
                 <div class="dropdown">
                     <button class="btn btn-secondary dropdown-toggle" type="button" id="configSelector" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         {% trans 'Reload with a different configuration' %}

--- a/csfieldguide/templates/interactives/pixel-viewer.html
+++ b/csfieldguide/templates/interactives/pixel-viewer.html
@@ -43,11 +43,15 @@
                     {% trans "Colour code: " %}
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="colourCode" id="rgb-colour-code" value="rgb" checked>
-                        <label class="form-check-label" for="rgb-colour-code">{% trans "RGB" %}</label>
+                        <label class="form-check-label" for="rgb-colour-code">{% trans "Decimal" %}</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" name="colourCode" value="rgb-hex" id="rgb-hex-colour-code">
+                        <label class="form-check-label" for="rgb-hex-colour-code">{% trans "Hexadecimal" %}</label>
                     </div>
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" name="colourCode" value="hex" id="hex-colour-code">
-                        <label class="form-check-label" for="hex-colour-code">{% trans "Hexadecimal" %}</label>
+                        <label class="form-check-label" for="hex-colour-code">{% trans "Web colour" %}</label>
                     </div>
                 </div>
                 <div class="dropdown">


### PR DESCRIPTION
**Changes**

- Users now have 3 different options for how colour codes should be displayed.
    - Decimal (as separate RGB values) **(default)**
    - Hexadecimal (as separate RGB values)
    - Hexadecimal (web colour)

- Add optional URL parameter `colour-code` that sets what colour code the interactive loads with. Values are:
    - `rgb` (default)
    - `rgb-hex`
    - `hex`

- Update README.

Resolves #1277 