### PR TITLE
Implement hex v decimal option to Colour Mixer interactives

### DIFF
--- a/csfieldguide/static/interactives/cmy-mixer/README.md
+++ b/csfieldguide/static/interactives/cmy-mixer/README.md
@@ -2,9 +2,17 @@
 
 **Author:** Jack Morgan
 
+**Modified By:** Alasdair Smith
+
 This interactive is used to create colours using CMY values.
+
+## URL Parameter
+
+- `hex=true|false (default=false)`: if `true`, sets the interactive to display values in hexadecimal (0 - FF) rather than decimal (0 - 255).
 
 ## Required files
 
 The interactive loads from a base website template which includes a JavaScript file containing jQuery, Bootstrap, and a few other utilities and polyfills.
 See `static/js/website.js` for a full list.
+This interactive also requires nouislider.
+Its licence is listed in `LICENCE-THIRD-PARTY` with a full copy available in the `third-party-licences` directory.

--- a/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
+++ b/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
@@ -1,11 +1,15 @@
 // Adapted from http://refreshless.com/nouislider/examples/#section-colorpicker
 
+var urlParameters = require('../../../js/third-party/url-parameters.js')
 const noUiSlider = require('nouislider');
 const wNumb = require('wnumb');
+var useHex = 'false';
 
 CMY_Mixer = {};
 
 $(document).ready(function () {
+  useHex = urlParameters.getUrlParameter('hex') || 'false';
+
   CMY_Mixer.minimum = 0
   CMY_Mixer.maximum = 255
 
@@ -99,4 +103,14 @@ function cmy_to_rgb(c, m, y){
     g = 255 - m,
     b = 255 - y;
     return [r,g,b];
+}
+
+// Taken from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
+function componentToHex(c) {
+  var hex = c.toString(16);
+  return hex.length == 1 ? "0" + hex : hex;
+}
+
+function rgbToHex(r, g, b) {
+  return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
 }

--- a/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
+++ b/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
@@ -4,28 +4,30 @@ var urlParameters = require('../../../js/third-party/url-parameters.js')
 const noUiSlider = require('nouislider');
 var useHex = false;
 
+const sFormat = {
+  to: function (value) {
+    if (useHex) {
+      return decimalToHex(Math.round(value));
+    }
+    return Math.round(value);
+  },
+  from: function (value) {
+    return Math.round(Number(value));
+  }
+};
+
 CMY_Mixer = {};
+
+CMY_Mixer.minimum = 0
+CMY_Mixer.maximum = 255
+
+CMY_Mixer.sliders = document.getElementsByClassName('interactive-cmy-mixer-slider');
+CMY_Mixer.result = document.getElementById('interactive-cmy-mixer-result');
 
 $(document).ready(function () {
   useHex = (urlParameters.getUrlParameter('hex') || 'false') == 'true';
-
-  CMY_Mixer.minimum = 0
-  CMY_Mixer.maximum = 255
-
-  CMY_Mixer.sliders = document.getElementsByClassName('interactive-cmy-mixer-slider');
-  CMY_Mixer.result = document.getElementById('interactive-cmy-mixer-result');
-
-  const sFormat = {
-    to: function (value) {
-      if (useHex) {
-        return decimalToHex(Math.round(value));
-      }
-      return Math.round(value);
-    },
-    from: function (value) {
-      return Math.round(Number(value));
-    }
-  };
+  $("input[id='hex-colour-code']").prop('checked', useHex);
+  $("input[id='dec-colour-code']").prop('checked', !useHex);
 
   for ( var i = 0; i < CMY_Mixer.sliders.length; i++ ) {
     noUiSlider.create(CMY_Mixer.sliders[i], {
@@ -59,6 +61,58 @@ $(document).ready(function () {
 
   // Update display
   CMY_Mixer.setColor();
+});
+
+
+$("input[name='colourCode']").click(function() {
+  var temp = $("input[name='colourCode']:checked").val() == 'hex';
+  if (temp != useHex) {
+    useHex = temp;
+    var c_val = $('#interactive-cmy-mixer-cyan-value').val() || 0;
+    var m_val = $('#interactive-cmy-mixer-magenta-value').val() || 0;
+    var y_val = $('#interactive-cmy-mixer-yellow-value').val() || 0;
+    var vals = [c_val, m_val, y_val];
+
+    if (useHex) {
+      c_val = decimalToHex(parseInt(c_val));
+      m_val = decimalToHex(parseInt(m_val));
+      y_val = decimalToHex(parseInt(y_val));
+    } else {
+      c_val = parseInt(c_val, 16);
+      m_val = parseInt(m_val, 16);
+      y_val = parseInt(y_val, 16);
+      vals = [c_val, m_val, y_val];
+    }
+    $('#interactive-cmy-mixer-cyan-value').val(c_val);
+    $('#interactive-cmy-mixer-magenta-value').val(m_val);
+    $('#interactive-cmy-mixer-yellow-value').val(y_val);
+
+    for ( var i = 0; i < CMY_Mixer.sliders.length; i++ ) {
+      CMY_Mixer.sliders[i].noUiSlider.destroy();
+      noUiSlider.create(CMY_Mixer.sliders[i], {
+        start: vals[i],
+        step: 1,
+        connect: "lower",
+        orientation: "horizontal",
+        range: {
+          'min': CMY_Mixer.minimum,
+          'max': CMY_Mixer.maximum
+        },
+        format: sFormat,
+        pips: {
+          mode: 'count',
+          values: 9,
+          density: 9,
+          stepped: true,
+          format: sFormat
+        }
+      });
+    }
+  }
+  
+  CMY_Mixer.sliders[0].noUiSlider.on('update', CMY_Mixer.setColor);
+  CMY_Mixer.sliders[1].noUiSlider.on('update', CMY_Mixer.setColor);
+  CMY_Mixer.sliders[2].noUiSlider.on('update', CMY_Mixer.setColor);
 });
 
 

--- a/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
+++ b/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
@@ -2,19 +2,30 @@
 
 var urlParameters = require('../../../js/third-party/url-parameters.js')
 const noUiSlider = require('nouislider');
-const wNumb = require('wnumb');
-var useHex = 'false';
+var useHex = false;
 
 CMY_Mixer = {};
 
 $(document).ready(function () {
-  useHex = urlParameters.getUrlParameter('hex') || 'false';
+  useHex = (urlParameters.getUrlParameter('hex') || 'false') == 'true';
 
   CMY_Mixer.minimum = 0
   CMY_Mixer.maximum = 255
 
   CMY_Mixer.sliders = document.getElementsByClassName('interactive-cmy-mixer-slider');
   CMY_Mixer.result = document.getElementById('interactive-cmy-mixer-result');
+
+  const sFormat = {
+    to: function (value) {
+      if (useHex) {
+        return decimalToHex(Math.round(value));
+      }
+      return Math.round(value);
+    },
+    from: function (value) {
+      return Math.round(Number(value));
+    }
+  };
 
   for ( var i = 0; i < CMY_Mixer.sliders.length; i++ ) {
     noUiSlider.create(CMY_Mixer.sliders[i], {
@@ -26,14 +37,13 @@ $(document).ready(function () {
         'min': CMY_Mixer.minimum,
         'max': CMY_Mixer.maximum
       },
-      format: wNumb({
-        decimals: 0
-      }),
+      format: sFormat,
       pips: {
         mode: 'count',
     		values: 9,
     		density: 9,
-		    stepped: true
+        stepped: true,
+        format: sFormat
     	}
     });
   }
@@ -53,11 +63,19 @@ $(document).ready(function () {
 
 
 CMY_Mixer.setColor = function(){
-	// Get the slider values,
-	// stick them together.
-  var cmy_as_rgb = cmy_to_rgb(CMY_Mixer.sliders[0].noUiSlider.get(),
-                              CMY_Mixer.sliders[1].noUiSlider.get(),
-                              CMY_Mixer.sliders[2].noUiSlider.get());
+  // Get the slider values,
+  var cyan_val = CMY_Mixer.sliders[0].noUiSlider.get();
+  var magenta_val = CMY_Mixer.sliders[1].noUiSlider.get();
+  var yellow_val = CMY_Mixer.sliders[2].noUiSlider.get();
+  // stick them together.
+  var cmy_as_rgb;
+  if (useHex) {
+    cmy_as_rgb = cmy_to_rgb(parseInt(cyan_val, 16),
+                            parseInt(magenta_val, 16),
+                            parseInt(yellow_val, 16));
+  } else {
+    cmy_as_rgb = cmy_to_rgb(cyan_val, magenta_val, yellow_val);
+  }
 	var color = 'rgb(' +
 		cmy_as_rgb[0] + ',' +
 		cmy_as_rgb[1] + ',' +
@@ -76,10 +94,15 @@ CMY_Mixer.setColor = function(){
 
 CMY_Mixer.setColorFromInputBox = function() {
   // Get the input values
-  cyan_val = $('#interactive-cmy-mixer-cyan-value').val();
-  magenta_val = $('#interactive-cmy-mixer-magenta-value').val();
-  yellow_val = $('#interactive-cmy-mixer-yellow-value').val();
+  cyan_val = $('#interactive-cmy-mixer-cyan-value').val() || 0;
+  magenta_val = $('#interactive-cmy-mixer-magenta-value').val() || 0;
+  yellow_val = $('#interactive-cmy-mixer-yellow-value').val() || 0;
 	// stick them together.
+  if (useHex) {
+    cyan_val = parseInt(cyan_val, 16);
+    magenta_val = parseInt(magenta_val, 16);
+    yellow_val = parseInt(yellow_val, 16);
+  }
   var cmy_as_rgb = cmy_to_rgb(cyan_val, magenta_val, yellow_val);
 
 	var color = 'rgb(' +
@@ -97,20 +120,15 @@ CMY_Mixer.setColorFromInputBox = function() {
   CMY_Mixer.sliders[2].noUiSlider.set(yellow_val);
 }
 
-function cmy_to_rgb(c, m, y){
-    var
-    r = 255 - c,
-    g = 255 - m,
-    b = 255 - y;
-    return [r,g,b];
+function cmy_to_rgb(c, m, y) {
+  var
+  r = 255 - c,
+  g = 255 - m,
+  b = 255 - y;
+  return [r,g,b];
 }
 
-// Taken from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
-function componentToHex(c) {
-  var hex = c.toString(16);
-  return hex.length == 1 ? "0" + hex : hex;
-}
-
-function rgbToHex(r, g, b) {
-  return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+function decimalToHex(d) {
+  var hex = d.toString(16).toUpperCase();
+  return hex;
 }

--- a/csfieldguide/static/interactives/cmy-mixer/package.json
+++ b/csfieldguide/static/interactives/cmy-mixer/package.json
@@ -3,7 +3,6 @@
     "version": "1.0.0",
     "private": true,
     "dependencies": {
-        "nouislider": "13.1.5",
-        "wnumb": "1.1.0"
+        "nouislider": "13.1.5"
     }
 }

--- a/csfieldguide/static/interactives/rgb-mixer/README.md
+++ b/csfieldguide/static/interactives/rgb-mixer/README.md
@@ -2,11 +2,17 @@
 
 **Author:** Jack Morgan
 
+**Modified By:** Alasdair Smith
+
 This interactive is used to create colours using RGB values.
+
+## URL Parameter
+
+- `hex=true|false (default=false)`: if `true`, sets the interactive to display values in hexadecimal (0 - FF) rather than decimal (0 - 255).
 
 ## Required files
 
 The interactive loads from a base website template which includes a JavaScript file containing jQuery, Bootstrap, and a few other utilities and polyfills.
 See `static/js/website.js` for a full list.
-This interactive also requires nouislider and wnumb.
-Their licences are listed in `LICENCE-THIRD-PARTY` with full copies available in the `third-party-licences` directory.
+This interactive also requires nouislider.
+Its licence is listed in `LICENCE-THIRD-PARTY` with a full copy available in the `third-party-licences` directory.

--- a/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
+++ b/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
@@ -4,28 +4,30 @@ var urlParameters = require('../../../js/third-party/url-parameters.js')
 const noUiSlider = require('nouislider');
 var useHex = false;
 
+const sFormat = {
+  to: function (value) {
+    if (useHex) {
+      return decimalToHex(Math.round(value));
+    }
+    return Math.round(value);
+  },
+  from: function (value) {
+    return Math.round(Number(value));
+  }
+};
+
 RGB_Mixer = {};
+
+RGB_Mixer.minimum = 0
+RGB_Mixer.maximum = 255
+
+RGB_Mixer.sliders = document.getElementsByClassName('interactive-rgb-mixer-slider');
+RGB_Mixer.result = document.getElementById('interactive-rgb-mixer-result');
 
 $(document).ready(function () {
   useHex = (urlParameters.getUrlParameter('hex') || 'false') == 'true';
-
-  RGB_Mixer.minimum = 0
-  RGB_Mixer.maximum = 255
-
-  RGB_Mixer.sliders = document.getElementsByClassName('interactive-rgb-mixer-slider');
-  RGB_Mixer.result = document.getElementById('interactive-rgb-mixer-result');
-
-  const sFormat = {
-    to: function (value) {
-      if (useHex) {
-        return decimalToHex(Math.round(value));
-      }
-      return Math.round(value);
-    },
-    from: function (value) {
-      return Math.round(Number(value));
-    }
-  };
+  $("input[id='hex-colour-code']").prop('checked', useHex);
+  $("input[id='dec-colour-code']").prop('checked', !useHex);
 
   for ( var i = 0; i < RGB_Mixer.sliders.length; i++ ) {
     noUiSlider.create(RGB_Mixer.sliders[i], {
@@ -62,7 +64,59 @@ $(document).ready(function () {
 });
 
 
-RGB_Mixer.setColor = function(){
+$("input[name='colourCode']").click(function() {
+  var temp = $("input[name='colourCode']:checked").val() == 'hex';
+  if (temp != useHex) {
+    useHex = temp;
+    var r_val = $('#interactive-rgb-mixer-red-value').val() || 0;
+    var g_val = $('#interactive-rgb-mixer-green-value').val() || 0;
+    var b_val = $('#interactive-rgb-mixer-blue-value').val() || 0;
+    var vals = [r_val, g_val, b_val];
+
+    if (useHex) {
+      r_val = decimalToHex(parseInt(r_val));
+      g_val = decimalToHex(parseInt(g_val));
+      b_val = decimalToHex(parseInt(b_val));
+    } else {
+      r_val = parseInt(r_val, 16);
+      g_val = parseInt(g_val, 16);
+      b_val = parseInt(b_val, 16);
+      vals = [r_val, g_val, b_val];
+    }
+    $('#interactive-rgb-mixer-red-value').val(r_val);
+    $('#interactive-rgb-mixer-green-value').val(g_val);
+    $('#interactive-rgb-mixer-blue-value').val(b_val);
+
+    for ( var i = 0; i < RGB_Mixer.sliders.length; i++ ) {
+      RGB_Mixer.sliders[i].noUiSlider.destroy();
+      noUiSlider.create(RGB_Mixer.sliders[i], {
+        start: vals[i],
+        step: 1,
+        connect: "lower",
+        orientation: "horizontal",
+        range: {
+          'min': RGB_Mixer.minimum,
+          'max': RGB_Mixer.maximum
+        },
+        format: sFormat,
+        pips: {
+          mode: 'count',
+          values: 9,
+          density: 9,
+          stepped: true,
+          format: sFormat
+        }
+      });
+    }
+  }
+
+  RGB_Mixer.sliders[0].noUiSlider.on('update', RGB_Mixer.setColor);
+  RGB_Mixer.sliders[1].noUiSlider.on('update', RGB_Mixer.setColor);
+  RGB_Mixer.sliders[2].noUiSlider.on('update', RGB_Mixer.setColor);
+});
+
+
+RGB_Mixer.setColor = function() {
   // Get the slider values,
   var r_val = RGB_Mixer.sliders[0].noUiSlider.get();
   var g_val = RGB_Mixer.sliders[1].noUiSlider.get();

--- a/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
+++ b/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
@@ -2,16 +2,30 @@
 
 var urlParameters = require('../../../js/third-party/url-parameters.js')
 const noUiSlider = require('nouislider');
-const wNumb = require('wnumb');
+var useHex = false;
 
 RGB_Mixer = {};
 
 $(document).ready(function () {
+  useHex = (urlParameters.getUrlParameter('hex') || 'false') == 'true';
+
   RGB_Mixer.minimum = 0
   RGB_Mixer.maximum = 255
 
   RGB_Mixer.sliders = document.getElementsByClassName('interactive-rgb-mixer-slider');
   RGB_Mixer.result = document.getElementById('interactive-rgb-mixer-result');
+
+  const sFormat = {
+    to: function (value) {
+      if (useHex) {
+        return decimalToHex(Math.round(value));
+      }
+      return Math.round(value);
+    },
+    from: function (value) {
+      return Math.round(Number(value));
+    }
+  };
 
   for ( var i = 0; i < RGB_Mixer.sliders.length; i++ ) {
     noUiSlider.create(RGB_Mixer.sliders[i], {
@@ -23,14 +37,13 @@ $(document).ready(function () {
         'min': RGB_Mixer.minimum,
         'max': RGB_Mixer.maximum
       },
-      format: wNumb({
-        decimals: 0
-      }),
+      format: sFormat,
       pips: {
         mode: 'count',
     		values: 9,
     		density: 9,
-		    stepped: true
+        stepped: true,
+        format: sFormat
     	}
     });
   }
@@ -50,12 +63,20 @@ $(document).ready(function () {
 
 
 RGB_Mixer.setColor = function(){
-	// Get the slider values,
+  // Get the slider values,
+  var r_val = RGB_Mixer.sliders[0].noUiSlider.get();
+  var g_val = RGB_Mixer.sliders[1].noUiSlider.get();
+  var b_val = RGB_Mixer.sliders[2].noUiSlider.get();
 	// stick them together.
+  if (useHex) {
+    r_val = parseInt(r_val, 16);
+    g_val = parseInt(g_val, 16);
+    b_val = parseInt(b_val, 16);
+  }
 	var color = 'rgb(' +
-		RGB_Mixer.sliders[0].noUiSlider.get() + ',' +
-		RGB_Mixer.sliders[1].noUiSlider.get() + ',' +
-		RGB_Mixer.sliders[2].noUiSlider.get() + ')';
+		r_val + ',' +
+		g_val + ',' +
+		b_val + ')';
 
 	// Fill the color box.
 	RGB_Mixer.result.style.background = color;
@@ -69,10 +90,15 @@ RGB_Mixer.setColor = function(){
 
 RGB_Mixer.setColorFromInputBox = function(){
   // Get the slider values,
-  red_val = $('#interactive-rgb-mixer-red-value').val();
-  green_val = $('#interactive-rgb-mixer-green-value').val();
-  blue_val = $('#interactive-rgb-mixer-blue-value').val();
+  red_val = $('#interactive-rgb-mixer-red-value').val() || 0;
+  green_val = $('#interactive-rgb-mixer-green-value').val() || 0;
+  blue_val = $('#interactive-rgb-mixer-blue-value').val() || 0;
 	// stick them together.
+  if (useHex) {
+    red_val = parseInt(red_val, 16);
+    green_val = parseInt(green_val, 16);
+    blue_val = parseInt(blue_val, 16);
+  }
 	var color = 'rgb(' + red_val + ',' + green_val + ',' + blue_val + ')';
 
 	// Fill the color box.
@@ -84,3 +110,8 @@ RGB_Mixer.setColorFromInputBox = function(){
   RGB_Mixer.sliders[1].noUiSlider.set(green_val);
   RGB_Mixer.sliders[2].noUiSlider.set(blue_val);
 };
+
+function decimalToHex(d) {
+  var hex = d.toString(16).toUpperCase();
+  return hex;
+}

--- a/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
+++ b/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
@@ -1,5 +1,6 @@
 // Adapted from http://refreshless.com/nouislider/examples/#section-colorpicker
 
+var urlParameters = require('../../../js/third-party/url-parameters.js')
 const noUiSlider = require('nouislider');
 const wNumb = require('wnumb');
 

--- a/csfieldguide/static/interactives/rgb-mixer/package.json
+++ b/csfieldguide/static/interactives/rgb-mixer/package.json
@@ -3,7 +3,6 @@
     "version": "1.0.0",
     "private": true,
     "dependencies": {
-        "nouislider": "13.1.5",
-        "wnumb": "1.1.0"
+        "nouislider": "13.1.5"
     }
 }

--- a/csfieldguide/templates/interactives/cmy-mixer.html
+++ b/csfieldguide/templates/interactives/cmy-mixer.html
@@ -23,6 +23,16 @@
           </div>
         </div>
     </div>
+    <div class="m-1">
+      <div class="form-check form-check-inline">
+          <input class="form-check-input" type="radio" name="colourCode" value="dec" id="dec-colour-code" checked>
+          <label class="form-check-label" for="dec-colour-code">{% trans "Decimal" %}</label>
+      </div>
+      <div class="form-check form-check-inline">
+          <input class="form-check-input" type="radio" name="colourCode" value="hex" id="hex-colour-code">
+          <label class="form-check-label" for="hex-colour-code">{% trans "Hexadecimal" %}</label>
+      </div>
+    </div>
   </div>
 {% endblock html %}
 

--- a/csfieldguide/templates/interactives/rgb-mixer.html
+++ b/csfieldguide/templates/interactives/rgb-mixer.html
@@ -23,6 +23,16 @@
           </div>
       </div>
     </div>
+    <div class="m-1">
+      <div class="form-check form-check-inline">
+          <input class="form-check-input" type="radio" name="colourCode" value="dec" id="dec-colour-code" checked>
+          <label class="form-check-label" for="dec-colour-code">{% trans "Decimal" %}</label>
+      </div>
+      <div class="form-check form-check-inline">
+          <input class="form-check-input" type="radio" name="colourCode" value="hex" id="hex-colour-code">
+          <label class="form-check-label" for="hex-colour-code">{% trans "Hexadecimal" %}</label>
+      </div>
+    </div>
   </div>
 {% endblock html %}
 


### PR DESCRIPTION
Resolves #1290 

- Add URL parameter `hex=true|false`
- Add radio buttons for hexadecimal/decimal option
- Allow input box and slider pips to use hexadecimal values when required
- Implement ability to switch between hex and decimal versions of input box and sliders

I don't think it's worth it to try and enforce a two-digit hexadecimal (i.e. 00 - 0F instead of 0 - F), while still allowing users to type in the values they want to set the sliders to