### PR TITLE
Fix up Pixel Viewer and RGB mixer plus modernise CMY mixer

### DIFF
--- a/csfieldguide/general/urls.py
+++ b/csfieldguide/general/urls.py
@@ -57,7 +57,7 @@ urlpatterns = [
         "pixelmania-2",
         RedirectView.as_view(
             permanent=True,
-            url="interactives/centered/rgb-mixer/?mode=pixelmania"
+            url="interactives/centered/rgb-mixer/?hex=true&hide-selector=true&pixelmania"
         ),
     ),
     path(

--- a/csfieldguide/static/interactives/cmy-mixer/README.md
+++ b/csfieldguide/static/interactives/cmy-mixer/README.md
@@ -6,9 +6,10 @@
 
 This interactive is used to create colours using CMY values.
 
-## URL Parameter
+## URL Parameters
 
 - `hex=true|false (default=false)`: if `true`, sets the interactive to display values in hexadecimal (0 - FF) rather than decimal (0 - 255).
+- `hide-selector=true|false (default=false)`: If `true`, hides the option to choose between decimal and hexadecimal notations.
 
 ## Required files
 

--- a/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
+++ b/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
@@ -134,14 +134,31 @@ CMY_Mixer.setColor = function(){
   } else {
     cmy_as_rgb = cmy_to_rgb(cyan_val, magenta_val, yellow_val);
   }
-	var color = 'rgb(' +
-		cmy_as_rgb[0] + ',' +
-		cmy_as_rgb[1] + ',' +
-		cmy_as_rgb[2] + ')';
 
-	// Fill the color box.
-	CMY_Mixer.result.style.background = color;
-	CMY_Mixer.result.style.color = color;
+  if (!useHex) {
+    // Display colour as text in coloured box
+    // There is no equivalent hex representation of colour in CMY
+    // _technically_ it should be CMYK since this is describing what printers do, but let's not get into that
+    var font_colour = getFontColour(cmy_as_rgb[0], cmy_as_rgb[1], cmy_as_rgb[2]);
+    var colour_text = 'cmy(' +
+      cyan_val + ',' +
+      magenta_val + ',' +
+      yellow_val + ')';
+    $('#interactive-cmy-mixer-colour-code')
+      .text(colour_text)
+      .css('color', font_colour);
+    } else {
+      $('#interactive-cmy-mixer-colour-code').text('');
+    }
+
+  var color = 'rgb(' +
+    cmy_as_rgb[0] + ',' +
+    cmy_as_rgb[1] + ',' +
+    cmy_as_rgb[2] + ')';
+
+  // Fill the color box.
+  CMY_Mixer.result.style.background = color;
+  CMY_Mixer.result.style.color = color;
 
   // Set text for labels
   $('#interactive-cmy-mixer-cyan-value').val(CMY_Mixer.sliders[0].noUiSlider.get());
@@ -162,11 +179,26 @@ CMY_Mixer.setColorFromInputBox = function() {
     yellow_val = parseInt(yellow_val, 16);
   }
   var cmy_as_rgb = cmy_to_rgb(cyan_val, magenta_val, yellow_val);
+  
+  if (!useHex) {
+    // Display colour as text in coloured box
+    // There is no equivalent hex representation of colour in CMY
+    var font_colour = getFontColour(cmy_as_rgb[0], cmy_as_rgb[1], cmy_as_rgb[2]);
+    var colour_text = 'cmy(' +
+      cyan_val + ',' +
+      magenta_val + ',' +
+      yellow_val + ')';
+    $('#interactive-cmy-mixer-colour-code')
+      .text(colour_text)
+      .css('color', font_colour);
+  } else {
+    $('#interactive-cmy-mixer-colour-code').text('');
+  }
 
-	var color = 'rgb(' +
-		cmy_as_rgb[0] + ',' +
-		cmy_as_rgb[1] + ',' +
-		cmy_as_rgb[2] + ')';
+  var color = 'rgb(' +
+    cmy_as_rgb[0] + ',' +
+    cmy_as_rgb[1] + ',' +
+    cmy_as_rgb[2] + ')';
 
 	// Fill the color box.
 	CMY_Mixer.result.style.background = color;
@@ -189,4 +221,17 @@ function cmy_to_rgb(c, m, y) {
 function decimalToHex(d) {
   var hex = d.toString(16).toUpperCase();
   return hex;
+}
+
+/**
+ * Determines what the font colour of the hex/rgb code should be
+ * based on the background colour of the box.
+ */
+function getFontColour(r, g, b) {
+  // http://www.w3.org/TR/AERT#color-contrast
+  var brightness = Math.round(((parseInt(r) * 299) +
+                      (parseInt(g) * 587) +
+                      (parseInt(b) * 114)) / 1000);
+  var font_colour = (brightness > 125) ? 'black' : 'white';
+  return font_colour
 }

--- a/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
+++ b/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
@@ -135,21 +135,24 @@ CMY_Mixer.setColor = function(){
     cmy_as_rgb = cmy_to_rgb(cyan_val, magenta_val, yellow_val);
   }
 
+  // Display colour as text in coloured box
+  // _technically_ it should be CMYK since this is describing what printers do, but let's not get into that
+  var font_colour = getFontColour(cmy_as_rgb[0], cmy_as_rgb[1], cmy_as_rgb[2]);
+  var colour_text;
   if (!useHex) {
-    // Display colour as text in coloured box
-    // There is no equivalent hex representation of colour in CMY
-    // _technically_ it should be CMYK since this is describing what printers do, but let's not get into that
-    var font_colour = getFontColour(cmy_as_rgb[0], cmy_as_rgb[1], cmy_as_rgb[2]);
-    var colour_text = 'cmy(' +
+    colour_text = 'cmy(' +
       cyan_val + ',' +
       magenta_val + ',' +
       yellow_val + ')';
-    $('#interactive-cmy-mixer-colour-code')
-      .text(colour_text)
-      .css('color', font_colour);
-    } else {
-      $('#interactive-cmy-mixer-colour-code').text('');
-    }
+  } else {
+    colour_text = 'cmy(' +
+      decimalToHex(cyan_val, true) + ',' +
+      decimalToHex(magenta_val, true) + ',' +
+      decimalToHex(yellow_val, true) + ')';
+  }
+  $('#interactive-cmy-mixer-colour-code')
+    .text(colour_text)
+    .css('color', font_colour);
 
   var color = 'rgb(' +
     cmy_as_rgb[0] + ',' +
@@ -218,8 +221,15 @@ function cmy_to_rgb(c, m, y) {
   return [r,g,b];
 }
 
-function decimalToHex(d) {
+/**
+ * Returns a string of the given decimal number in hexadecimal
+ * If enforceTwoChar is true and the resulting hex is just one character, a 0 will be prepended
+ */
+function decimalToHex(d, enforceTwoChar=false) {
   var hex = d.toString(16).toUpperCase();
+  if (enforceTwoChar && hex.length == 1) {
+    hex = '0' + hex;
+  }
   return hex;
 }
 

--- a/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
+++ b/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
@@ -29,6 +29,10 @@ $(document).ready(function () {
   $("input[id='hex-colour-code']").prop('checked', useHex);
   $("input[id='dec-colour-code']").prop('checked', !useHex);
 
+  if ((urlParameters.getUrlParameter('hide-selector') || 'false') == 'true') {
+    $("#numeral-system").addClass('d-none');
+  }
+
   for ( var i = 0; i < CMY_Mixer.sliders.length; i++ ) {
     noUiSlider.create(CMY_Mixer.sliders[i], {
       start: Math.floor(Math.random() * CMY_Mixer.maximum),

--- a/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
+++ b/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
@@ -120,7 +120,40 @@ $("input[name='colourCode']").click(function() {
 });
 
 
-CMY_Mixer.setColor = function(){
+/**
+ * Displays the given colour values as text and colours the coloured box
+ * _technically_ it should be CMYK since this is describing what printers do, but let's not get into that
+ */
+CMY_Mixer.writeColourBox = function(rgb_colour, cmy_colour) {
+  var font_colour = getFontColour(rgb_colour[0], rgb_colour[1], rgb_colour[2]);
+  var colour_text;
+  if (!useHex) {
+    colour_text = 'cmy(' +
+      cmy_colour[0] + ',' +
+      cmy_colour[1] + ',' +
+      cmy_colour[2] + ')';
+  } else {
+    colour_text = 'cmy(' +
+      '0x' + decimalToHex(cmy_colour[0], true) + ',' +
+      '0x' + decimalToHex(cmy_colour[1], true) + ',' +
+      '0x' + decimalToHex(cmy_colour[2], true) + ')';
+  }
+  $('#interactive-cmy-mixer-colour-code')
+    .text(colour_text)
+    .css('color', font_colour);
+
+  var color = 'rgb(' +
+    rgb_colour[0] + ',' +
+    rgb_colour[1] + ',' +
+    rgb_colour[2] + ')';
+
+  // Fill the color box.
+  CMY_Mixer.result.style.background = color;
+  CMY_Mixer.result.style.color = color;
+}
+
+
+CMY_Mixer.setColor = function() {
   // Get the slider values,
   var cyan_val = CMY_Mixer.sliders[0].noUiSlider.get();
   var magenta_val = CMY_Mixer.sliders[1].noUiSlider.get();
@@ -135,33 +168,7 @@ CMY_Mixer.setColor = function(){
     cmy_as_rgb = cmy_to_rgb(cyan_val, magenta_val, yellow_val);
   }
 
-  // Display colour as text in coloured box
-  // _technically_ it should be CMYK since this is describing what printers do, but let's not get into that
-  var font_colour = getFontColour(cmy_as_rgb[0], cmy_as_rgb[1], cmy_as_rgb[2]);
-  var colour_text;
-  if (!useHex) {
-    colour_text = 'cmy(' +
-      cyan_val + ',' +
-      magenta_val + ',' +
-      yellow_val + ')';
-  } else {
-    colour_text = 'cmy(' +
-      decimalToHex(cyan_val, true) + ',' +
-      decimalToHex(magenta_val, true) + ',' +
-      decimalToHex(yellow_val, true) + ')';
-  }
-  $('#interactive-cmy-mixer-colour-code')
-    .text(colour_text)
-    .css('color', font_colour);
-
-  var color = 'rgb(' +
-    cmy_as_rgb[0] + ',' +
-    cmy_as_rgb[1] + ',' +
-    cmy_as_rgb[2] + ')';
-
-  // Fill the color box.
-  CMY_Mixer.result.style.background = color;
-  CMY_Mixer.result.style.color = color;
+  CMY_Mixer.writeColourBox(cmy_as_rgb, [cyan_val, magenta_val, yellow_val]);
 
   // Set text for labels
   $('#interactive-cmy-mixer-cyan-value').val(CMY_Mixer.sliders[0].noUiSlider.get());
@@ -183,29 +190,7 @@ CMY_Mixer.setColorFromInputBox = function() {
   }
   var cmy_as_rgb = cmy_to_rgb(cyan_val, magenta_val, yellow_val);
   
-  if (!useHex) {
-    // Display colour as text in coloured box
-    // There is no equivalent hex representation of colour in CMY
-    var font_colour = getFontColour(cmy_as_rgb[0], cmy_as_rgb[1], cmy_as_rgb[2]);
-    var colour_text = 'cmy(' +
-      cyan_val + ',' +
-      magenta_val + ',' +
-      yellow_val + ')';
-    $('#interactive-cmy-mixer-colour-code')
-      .text(colour_text)
-      .css('color', font_colour);
-  } else {
-    $('#interactive-cmy-mixer-colour-code').text('');
-  }
-
-  var color = 'rgb(' +
-    cmy_as_rgb[0] + ',' +
-    cmy_as_rgb[1] + ',' +
-    cmy_as_rgb[2] + ')';
-
-	// Fill the color box.
-	CMY_Mixer.result.style.background = color;
-	CMY_Mixer.result.style.color = color;
+  CMY_Mixer.writeColourBox(cmy_as_rgb, [cyan_val, magenta_val, yellow_val]);
 
   // Set slider handle position
   CMY_Mixer.sliders[0].noUiSlider.set(cyan_val);

--- a/csfieldguide/static/interactives/cmy-mixer/scss/cmy-mixer.scss
+++ b/csfieldguide/static/interactives/cmy-mixer/scss/cmy-mixer.scss
@@ -43,8 +43,6 @@
 	background: yellow;
 }
 
-
-
 #interactive-cmy-mixer-colour-code {
   font: 1.5rem "Courier New", monospace;
   word-break: break-word;

--- a/csfieldguide/static/interactives/cmy-mixer/scss/cmy-mixer.scss
+++ b/csfieldguide/static/interactives/cmy-mixer/scss/cmy-mixer.scss
@@ -1,29 +1,33 @@
 @import "node_modules/nouislider/distribute/nouislider";
+@import "node_modules/bootstrap/scss/functions";
+@import "node_modules/bootstrap/scss/variables";
+@import "node_modules/bootstrap/scss/mixins";
 
 #interactive-cmy-mixer .noUi-pips {
   padding-top: 5px;
 }
+
 #interactive-cmy-mixer-container {
   display: flex;
   justify-content: space-between;
   padding-right: 1rem;
 }
+
 #interactive-cmy-mixer-result {
-  width: 22%;
 	background: rgb(127, 127, 127);
   color: rgb(127, 127, 127);
 	border: 1px solid black;
 	box-shadow: 0 0 10px;
 }
-#interactive-cmy-mixer-sliders {
-  width: 72%;
-}
+
 #interactive-cmy-mixer-sliders > div {
   padding-bottom: 5rem;
 }
+
 #interactive-cmy-mixer-sliders > div:last-child {
   padding-bottom: 3rem;
 }
+
 .interactive-cmy-mixer-slider {
   margin-top: 0.2rem;
 }
@@ -39,24 +43,36 @@
 	background: yellow;
 }
 
-/* Settings for displaying on small screens */
-@media (max-width: 259px) {
-  #interactive-cmy-mixer-container {
-    flex-direction: column;
-    padding-right: 0rem;
+
+
+#interactive-cmy-mixer-colour-code {
+  font: 1.5rem "Courier New", monospace;
+  word-break: break-word;
+}
+
+/* Settings for displaying on different sized screens */
+@include media-breakpoint-up(xl) {
+  #interactive-cmy-mixer {
+    padding: 10rem;
   }
-  #interactive-cmy-mixer-result {
-    width: 100%;
-    height: 5rem;
-    margin-bottom: 1rem;
+}
+
+@include media-breakpoint-up(lg) {
+  #interactive-cmy-mixer {
+    padding: 5rem;
   }
-  #interactive-cmy-mixer-sliders {
-    width: 100%;
+}
+
+@include media-breakpoint-up(md) {
+  #interactive-cmy-mixer {
+    padding: 2rem;
   }
-  #interactive-cmy-mixer .noUi-pips {
-    display: none;
-  }
-  #interactive-cmy-mixer-sliders > div {
-    padding-bottom: 1rem;
+}
+
+@include media-breakpoint-down(sm) {
+  // We should avoid using viewport height on mobile devices - https://chanind.github.io/javascript/2019/09/28/avoid-100vh-on-mobile-web.html
+  // Viewport height is used in the centered.html template.
+  #csfg-center-page-content {
+    height: auto !important;
   }
 }

--- a/csfieldguide/static/interactives/pixel-viewer/README.md
+++ b/csfieldguide/static/interactives/pixel-viewer/README.md
@@ -1,7 +1,7 @@
 # Pixel Viewer Interactive
 
 **Author:** Jack Morgan  
-**Modified by:** Andy Bell, Courtney Bracefield, Alasdair Smith
+**Modified by:** Andy Bell, Courtney Bracefield, Alasdair Smith, Jack Morgan
 
 This interactive is created to allow users to see the values of each pixel of an image.
 The user can zoom in and out of the image, and when close enough the pixel values are displayed.

--- a/csfieldguide/static/interactives/pixel-viewer/README.md
+++ b/csfieldguide/static/interactives/pixel-viewer/README.md
@@ -32,7 +32,7 @@ The interactive has the following optional parameters to configure the interacti
 - `hide-colour-code-picker` - Hides the option to change between colour code formats.
 - `hide-config-selector` - Hides the option to change between modes.
 - `no-pixel-fill` - Displays pixels without background fill from start (also doesn't show initial image with transition).
-- `pixelmania` - (for Pixelmania 2020) shows a small Pixelmania logo above the title in the menu.
+- `pixelmania` - (for Pixelmania 2020) Shows a small Pixelmania logo above the title in the menu.
 
 ## Required files
 

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -29,36 +29,36 @@ this.isGreyscale = false; // Global to keep track of whether greyscale is on
 
 // Names of images to be included in picture picker
 this.images = {
-    "coloured-roof-small.png": {
-        "image_position": {
-            "top": 1037,
-            "left": 794,
-        }
-    },
-    "lake.png": {
-        "image_position": {
-            "top": 3231,
-            "left": 4523,
-        }
-    },
-    "alley.jpg": {},
-    "arnold.jpg": {},
-    "bike.jpg": {},
-    "boards.jpg": {},
-    "dark_clock.jpg": {},
-    "dark.jpg": {},
-    "duck.jpg": {
-        "image_position": {
-            "top": 1121,
-            "left": 2919,
-        }
-    },
-    "fence.jpg": {},
-    "knight.png": {},
-    "roof.jpg": {},
-    "tuba.jpg": {},
-    "words_zoom.png": {},
-    "words.png": {},
+  "coloured-roof-small.png": {
+    "image_position": {
+      "top": 1037,
+      "left": 794,
+    }
+  },
+  "alley.jpg": {},
+  "arnold.jpg": {},
+  "bike.jpg": {},
+  "boards.jpg": {},
+  "dark_clock.jpg": {},
+  "dark.jpg": {},
+  "duck.jpg": {
+    "image_position": {
+      "top": 1121,
+      "left": 2919,
+    }
+  },
+  "fence.jpg": {},
+  "knight.png": {},
+  "lake.png": {
+    "image_position": {
+      "top": 3231,
+      "left": 4523,
+    }
+  },
+  "roof.jpg": {},
+  "tuba.jpg": {},
+  "words_zoom.png": {},
+  "words.png": {},
 }
 this.available_images = Object.keys(images)
 // Default image to load
@@ -134,14 +134,14 @@ $( document ).ready(function() {
 
   // Check if custom zoom parameters are given, otherwise default to 0,0.
     try {
-        image_position_top = images[image_filename]["image_position"]["top"];
+      image_position_top = images[image_filename]["image_position"]["top"];
     } catch (e) {
-        image_position_top = 0;
+      image_position_top = 0;
     }
     try {
-        image_position_left = images[image_filename]["image_position"]["left"];
+      image_position_left = images[image_filename]["image_position"]["left"];
     } catch (e) {
-        image_position_left = 0;
+      image_position_left = 0;
     }
     original_image_position_top = image_position_top * -1;
     scroller_position_top = image_position_top;
@@ -156,20 +156,20 @@ $( document ).ready(function() {
   } else {
     $("#pixel-viewer-interactive-original-image").show();
     $("#pixel-viewer-interactive-original-image").delay(1000).animate(
-        {
-            height: contentHeight * 0.8,
-            overflow: "hidden",
-            top: original_image_position_top.toString() + 'px',
-            left: original_image_position_left.toString() + 'px',
-            margin: 0
-        },
-        4000,
-        function() {
-            // Animation complete
-            scroller.scrollTo(scroller_position_left, scroller_position_top);
-            $("#pixel-viewer-interactive-loader").hide();
-            $("#pixel-viewer-interactive-buttons").css({opacity: 0, visibility: "visible"}).animate({opacity: 1}, 'slow');
-        }
+      {
+        height: contentHeight * 0.8,
+        overflow: "hidden",
+        top: original_image_position_top.toString() + 'px',
+        left: original_image_position_left.toString() + 'px',
+        margin: 0
+      },
+      4000,
+      function() {
+        // Animation complete
+        scroller.scrollTo(scroller_position_left, scroller_position_top);
+        $("#pixel-viewer-interactive-loader").hide();
+        $("#pixel-viewer-interactive-buttons").css({opacity: 0, visibility: "visible"}).animate({opacity: 1}, 'slow');
+      }
     );
     $("#pixel-viewer-interactive-original-image").fadeOut(300);
   }
@@ -913,43 +913,43 @@ function createPicturePicker(){
 }
 
 function loadImage(src){
-    //  Prevent any non-image file type from being read.
-    if(!src.type.match(/image.*/)){
-        console.log("The dropped file is not an image: ", src.type);
-        return;
-    }
+  //  Prevent any non-image file type from being read.
+  if(!src.type.match(/image.*/)){
+    console.log("The dropped file is not an image: ", src.type);
+    return;
+  }
   // Remove any noise added
   salt = null
 
-    //  Create our FileReader and run the results through the render function.
-    var reader = new FileReader();
-    reader.onload = function(e){
-        load_resize_image(e.target.result);
-    };
-    reader.readAsDataURL(src);
+  //  Create our FileReader and run the results through the render function.
+  var reader = new FileReader();
+  reader.onload = function(e){
+    load_resize_image(e.target.result);
+  };
+  reader.readAsDataURL(src);
 }
 
 function loadImageDialog(input) {
-    if (input.files && input.files[0]) {
-        var reader = new FileReader();
-        reader.onload = function (e) {
-            load_resize_image(e.target.result);
-        }
-        reader.readAsDataURL(input.files[0]);
+  if (input.files && input.files[0]) {
+    var reader = new FileReader();
+    reader.onload = function (e) {
+      load_resize_image(e.target.result);
     }
+    reader.readAsDataURL(input.files[0]);
+  }
 }
 
 $( "#pixel-viewer-interactive-menu-toggle" ).click(function() {
-    $( "#pixel-viewer-interactive-settings" ).toggleClass('menu-offscreen');
+  $( "#pixel-viewer-interactive-settings" ).toggleClass('menu-offscreen');
 });
 
 $('#pixel-viewer-interactive-show-pixel-fill').change(function() {
-    scroller.finishPullToRefresh();
+  scroller.finishPullToRefresh();
 });
 
 $("input[name='colourCode']").click(function() {
-    colour_code_rep = $("input[name='colourCode']:checked").val()
-    scroller.finishPullToRefresh();
+  colour_code_rep = $("input[name='colourCode']:checked").val()
+  scroller.finishPullToRefresh();
 })
 
 // Caches data about the image
@@ -979,127 +979,127 @@ function get_pixel_data(col, row){
 }
 
 function load_resize_image(src, user_upload=true){
-    var image = new Image();
-    image.onload = function(){
-        var canvas = document.getElementById("pixel-viewer-interactive-source-canvas");
-        if(image.height > MAX_HEIGHT) {
-            image.width *= MAX_HEIGHT / image.height;
-            image.height = MAX_HEIGHT;
-        }
-        var ctx = canvas.getContext("2d");
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        canvas.width = image.width;
-        canvas.height = image.height;
-        init_cache(image.width, image.height);
-        ctx.drawImage(image, 0, 0, image.width, image.height);
-        scroller.scrollTo(0,0);
-        if(user_upload){
-          var text = gettext("Your image has been resized for this interactive to " + image.width + " pixels wide and " + image.height + " pixels high.");
-          canvas.style.display = "inline-block";
-        }
-        else {
-          var text = "";
-          canvas.style.display = "hidden";
-        }
-        $( '#pixel-viewer-interactive-resize-values' ).text(text)
-    };
-    image.crossOrigin = 'anonymous'
-    image.src = src;
+  var image = new Image();
+  image.onload = function(){
+    var canvas = document.getElementById("pixel-viewer-interactive-source-canvas");
+    if(image.height > MAX_HEIGHT) {
+      image.width *= MAX_HEIGHT / image.height;
+      image.height = MAX_HEIGHT;
+    }
+    var ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    canvas.width = image.width;
+    canvas.height = image.height;
+    init_cache(image.width, image.height);
+    ctx.drawImage(image, 0, 0, image.width, image.height);
+    scroller.scrollTo(0,0);
+    if(user_upload){
+      var text = gettext("Your image has been resized for this interactive to " + image.width + " pixels wide and " + image.height + " pixels high.");
+      canvas.style.display = "inline-block";
+    }
+    else {
+    var text = "";
+    canvas.style.display = "hidden";
+    }
+    $( '#pixel-viewer-interactive-resize-values' ).text(text)
+  };
+  image.crossOrigin = 'anonymous'
+  image.src = src;
 }
 
 var target = document.body;
 target.addEventListener("dragover", function(e){e.preventDefault();}, true);
 target.addEventListener("drop", function(e){
-    e.preventDefault();
-    loadImage(e.dataTransfer.files[0]);
+  e.preventDefault();
+  loadImage(e.dataTransfer.files[0]);
 }, true);
 
 
 // Canvas renderer
 var render = function(left, top, zoom) {
-    // Full clearing
-    context.clearRect(0, 0, canvasWidth, canvasHeight);
+  // Full clearing
+  context.clearRect(0, 0, canvasWidth, canvasHeight);
 
-    // Use tiling
-    tiling.setup(canvasWidth, canvasHeight, contentWidth, contentHeight, CELL_SIZE, CELL_SIZE);
-    tiling.render(left, top, zoom, paint);
+  // Use tiling
+  tiling.setup(canvasWidth, canvasHeight, contentWidth, contentHeight, CELL_SIZE, CELL_SIZE);
+  tiling.render(left, top, zoom, paint);
 
-    // Variables to be calculated once per draw
-    // Calculate opacity of labels
-    text_opacity = zoom - 0.8
+  // Variables to be calculated once per draw
+  // Calculate opacity of labels
+  text_opacity = zoom - 0.8
 
-    if (text_opacity >= 1) {
-        text_opacity = 1;
-    } else if (text_opacity <= 0) {
-        text_opacity = 0;
-    }
+  if (text_opacity >= 1) {
+    text_opacity = 1;
+  } else if (text_opacity <= 0) {
+    text_opacity = 0;
+  }
 };
 
 // Initialize Scroller
 this.scroller = new Scroller(render, {
-    zooming: true,
-    bouncing: false,
-    locking: false,
-    animating: false,
-    paging: false,
-    snapping: false,
-    minZoom: 0.001,
-    maxZoom: 4
+  zooming: true,
+  bouncing: false,
+  locking: false,
+  animating: false,
+  paging: false,
+  snapping: false,
+  minZoom: 0.001,
+  maxZoom: 4
 });
 
 // Cell Paint Logic
 var paint = function(row, col, left, top, width, height, zoom) {
-    // Get data for pixel
-    var show_pixel_fill = document.getElementById('pixel-viewer-interactive-show-pixel-fill').checked;
-    var pixelData;
-    if (filter != null){
-      pixelData = filter(col, row);
-    }
-    else {
-      pixelData = get_pixel_data(col, row);
-    }
-    if (show_pixel_fill) {
-      context.fillStyle = 'rgb('+pixelData[0]+','+pixelData[1]+','+pixelData[2]+')';
-      context.fillRect(Math.round(left), Math.round(top), Math.round(width)+1, Math.round(height)+1);
+  // Get data for pixel
+  var show_pixel_fill = document.getElementById('pixel-viewer-interactive-show-pixel-fill').checked;
+  var pixelData;
+  if (filter != null){
+    pixelData = filter(col, row);
+  }
+  else {
+    pixelData = get_pixel_data(col, row);
+  }
+  if (show_pixel_fill) {
+    context.fillStyle = 'rgb('+pixelData[0]+','+pixelData[1]+','+pixelData[2]+')';
+    context.fillRect(Math.round(left), Math.round(top), Math.round(width)+1, Math.round(height)+1);
+  } else {
+    context.strokeRect(Math.round(left), Math.round(top), Math.round(width)+1, Math.round(height)+1);
+  }
+
+  // If text opacity is greater than 0, then display RGB values
+if (text_opacity > 0) {
+    if (!show_pixel_fill) {
+      context.fillStyle = "rgba(0, 0, 0, " + text_opacity + ")";
+    } else if ((((pixelData[0] / 255) + (pixelData[1] / 255) + (pixelData[2] / 255)) / 3) < 0.85) {
+      context.fillStyle = "rgba(255, 255, 255, " + text_opacity + ")";
     } else {
-      context.strokeRect(Math.round(left), Math.round(top), Math.round(width)+1, Math.round(height)+1);
+      context.fillStyle = "rgba(110, 110, 110, " + text_opacity + ")";
     }
 
-    // If text opacity is greater than 0, then display RGB values
-    if (text_opacity > 0) {
-        if (!show_pixel_fill) {
-            context.fillStyle = "rgba(0, 0, 0, " + text_opacity + ")";
-        } else if ((((pixelData[0] / 255) + (pixelData[1] / 255) + (pixelData[2] / 255)) / 3) < 0.85) {
-            context.fillStyle = "rgba(255, 255, 255, " + text_opacity + ")";
-        } else {
-            context.fillStyle = "rgba(110, 110, 110, " + text_opacity + ")";
+    // Pretty primitive text positioning
+    if (colour_code_rep == 'hex') { // Shows colour codes in #FFFFFF style
+      context.font = (10 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
+      r = pixelData[0];
+      g = pixelData[1];
+      b = pixelData[2];
+      hex_string = rgbToHex(r, g, b);
+      context.fillText(hex_string, left + (4 * zoom), top + (14 * zoom) + (cell_line_height * zoom));
+    } else if (colour_code_rep == 'brightness') {
+      context.font = (10 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
+      brightness = Math.round(average(pixelData));
+      context.fillText(brightness, left + (16 * zoom), top + (14 * zoom) + (cell_line_height * zoom));
+    } else {
+      context.font = (14 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
+      var cell_lines = cell_text.split('\n');
+      for (var i = 0; i < cell_lines.length; i++) {
+        if (colour_code_rep == 'rgb-hex') { // Shows colour codes in RGB using Hexadecimal
+          value = componentToHex(pixelData[i])
+        } else { // Shows colour codes in RGB using Decimal
+          value = pixelData[i]
         }
-
-        // Pretty primitive text positioning
-        if (colour_code_rep == 'hex') { // Shows colour codes in #FFFFFF style
-          context.font = (10 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
-          r = pixelData[0];
-          g = pixelData[1];
-          b = pixelData[2];
-          hex_string = rgbToHex(r, g, b);
-          context.fillText(hex_string, left + (4 * zoom), top + (14 * zoom) + (cell_line_height * zoom));
-        } else if (colour_code_rep == 'brightness') {
-          context.font = (10 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
-          brightness = Math.round(average(pixelData));
-          context.fillText(brightness, left + (16 * zoom), top + (14 * zoom) + (cell_line_height * zoom));
-        } else {
-          context.font = (14 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
-          var cell_lines = cell_text.split('\n');
-          for (var i = 0; i < cell_lines.length; i++) {
-            if (colour_code_rep == 'rgb-hex') { // Shows colour codes in RGB using Hexadecimal
-              value = componentToHex(pixelData[i])
-            } else { // Shows colour codes in RGB using Decimal
-              value = pixelData[i]
-            }
-            context.fillText(cell_lines[i] + value, left + (6 * zoom), top + (14 * zoom) + (i * cell_line_height * zoom));
-          }
-        }
+        context.fillText(cell_lines[i] + value, left + (6 * zoom), top + (14 * zoom) + (i * cell_line_height * zoom));
+      }
     }
+  }
 };
 
 // Taken from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
@@ -1117,12 +1117,12 @@ scroller.setPosition(rect.left + container.clientLeft, rect.top + container.clie
 
 // Reflow handling
 var reflow = function() {
-    canvasWidth = container.clientWidth;
-    canvasHeight = container.clientHeight;
-    // Sync current dimensions with canvas
-    content.width = canvasWidth;
-    content.height = canvasHeight;
-    scroller.setDimensions(canvasWidth, canvasHeight, contentWidth, contentHeight);
+  canvasWidth = container.clientWidth;
+  canvasHeight = container.clientHeight;
+  // Sync current dimensions with canvas
+  content.width = canvasWidth;
+  content.height = canvasHeight;
+  scroller.setDimensions(canvasWidth, canvasHeight, contentWidth, contentHeight);
 };
 
 // Set zoom to see numbers if no colour fill
@@ -1133,94 +1133,94 @@ if (getUrlParameter('no-pixel-fill')) {
 window.addEventListener("resize", reflow, false);
 
 document.querySelector("#pixel-viewer-interactive-zoom-in").addEventListener("click", function() {
-    scroller.zoomBy(1.2, true);
+  scroller.zoomBy(1.2, true);
 }, false);
 
 document.querySelector("#pixel-viewer-interactive-zoom-out").addEventListener("click", function() {
-    scroller.zoomBy(0.8, true);
+  scroller.zoomBy(0.8, true);
 }, false);
 
 if ('ontouchstart' in window) {
 
-    content.addEventListener("touchstart", function(e) {
-        // Don't react if initial down happens on a form element
-        if (e.touches[0] && e.touches[0].target && e.touches[0].target.tagName.match(/input|textarea|select/i)) {
-            return;
-        }
+  content.addEventListener("touchstart", function(e) {
+    // Don't react if initial down happens on a form element
+    if (e.touches[0] && e.touches[0].target && e.touches[0].target.tagName.match(/input|textarea|select/i)) {
+      return;
+    }
 
-        scroller.doTouchStart(e.touches, e.timeStamp);
-        e.preventDefault();
-    }, false);
+    scroller.doTouchStart(e.touches, e.timeStamp);
+    e.preventDefault();
+  }, false);
 
-    document.addEventListener("touchmove", function(e) {
-        scroller.doTouchMove(e.touches, e.timeStamp, e.scale);
-    }, false);
+  document.addEventListener("touchmove", function(e) {
+    scroller.doTouchMove(e.touches, e.timeStamp, e.scale);
+  }, false);
 
-    document.addEventListener("touchend", function(e) {
-        scroller.doTouchEnd(e.timeStamp);
-    }, false);
+  document.addEventListener("touchend", function(e) {
+    scroller.doTouchEnd(e.timeStamp);
+  }, false);
 
-    document.addEventListener("touchcancel", function(e) {
-        scroller.doTouchEnd(e.timeStamp);
-    }, false);
+  document.addEventListener("touchcancel", function(e) {
+    scroller.doTouchEnd(e.timeStamp);
+  }, false);
 
 } else {
 
-    var mousedown = false;
+  var mousedown = false;
 
-    content.addEventListener("mousedown", function(e) {
-        if (e.target.tagName.match(/input|textarea|select/i)) {
-            return;
-        }
+  content.addEventListener("mousedown", function(e) {
+    if (e.target.tagName.match(/input|textarea|select/i)) {
+      return;
+    }
 
-        scroller.doTouchStart([{
-            pageX: e.pageX,
-            pageY: e.pageY
-        }], e.timeStamp);
+    scroller.doTouchStart([{
+      pageX: e.pageX,
+      pageY: e.pageY
+    }], e.timeStamp);
 
-        mousedown = true;
-    }, false);
+    mousedown = true;
+  }, false);
 
-    document.addEventListener("mousemove", function(e) {
-        if (!mousedown) {
-            return;
-        }
+  document.addEventListener("mousemove", function(e) {
+    if (!mousedown) {
+      return;
+    }
 
-        scroller.doTouchMove([{
-            pageX: e.pageX,
-            pageY: e.pageY
-        }], e.timeStamp);
+    scroller.doTouchMove([{
+      pageX: e.pageX,
+      pageY: e.pageY
+    }], e.timeStamp);
 
-        mousedown = true;
-    }, false);
+    mousedown = true;
+  }, false);
 
-    document.addEventListener("mouseup", function(e) {
-        if (!mousedown) {
-            return;
-        }
+  document.addEventListener("mouseup", function(e) {
+    if (!mousedown) {
+      return;
+    }
 
-        scroller.doTouchEnd(e.timeStamp);
+    scroller.doTouchEnd(e.timeStamp);
 
-        mousedown = false;
-    }, false);
+    mousedown = false;
+  }, false);
 
-    content.addEventListener(navigator.userAgent.indexOf("Firefox") > -1 ? "DOMMouseScroll" :  "mousewheel", function(e) {
-      // following inspired by https://deepmikoto.com/coding/1--javascript-detect-mouse-wheel-direction
-        e.preventDefault();
-        var delta;
-        var direction;
-        if (e.wheelDelta) { // will work in most cases
-            delta = e.wheelDelta / 60;
-        } else if (e.detail) { // fallback for Firefox
-            delta = -e.detail / 2;
-        }
-        direction = delta > 0 ? 'up' : 'down';
-        if (direction == 'up') {
-            scroller.zoomBy(1.2, true);
-        } else if (direction == 'down') {
-            scroller.zoomBy(0.8, true);
-        }
-    }, false);
+  content.addEventListener(navigator.userAgent.indexOf("Firefox") > -1 ? "DOMMouseScroll" :  "mousewheel", function(e) {
+  // following inspired by https://deepmikoto.com/coding/1--javascript-detect-mouse-wheel-direction
+    e.preventDefault();
+    var delta;
+    var direction;
+    if (e.wheelDelta) { // will work in most cases
+      delta = e.wheelDelta / 60;
+    } else if (e.detail) { // fallback for Firefox
+      delta = -e.detail / 2;
+    }
+    direction = delta > 0 ? 'up' : 'down';
+    if (direction == 'up') {
+      scroller.zoomBy(1.2, true);
+    } else if (direction == 'down') {
+      scroller.zoomBy(0.8, true);
+    }
+  }, false);
 
 }
 
@@ -1236,22 +1236,22 @@ function randomInt(max){
 
 function sum(array){
   return array.reduce(function(prev, curr, currI, arr){
-        return prev + curr;
+    return prev + curr;
   });
 }
 
 // From jquerybyexample.net/2012/06/get-url-parameters-using-jquery.html
 function getUrlParameter(sParam) {
-    var sPageURL = decodeURIComponent(window.location.search.substring(1)),
-        sURLVariables = sPageURL.split('&'),
-        sParameterName,
-        i;
+  var sPageURL = decodeURIComponent(window.location.search.substring(1)),
+      sURLVariables = sPageURL.split('&'),
+      sParameterName,
+      i;
 
-    for (i = 0; i < sURLVariables.length; i++) {
-        sParameterName = sURLVariables[i].split('=');
+  for (i = 0; i < sURLVariables.length; i++) {
+    sParameterName = sURLVariables[i].split('=');
 
-        if (sParameterName[0] === sParam) {
-            return sParameterName[1] === undefined ? true : sParameterName[1];
-        }
+    if (sParameterName[0] === sParam) {
+      return sParameterName[1] === undefined ? true : sParameterName[1];
     }
+  }
 };

--- a/csfieldguide/static/interactives/rgb-mixer/README.md
+++ b/csfieldguide/static/interactives/rgb-mixer/README.md
@@ -2,7 +2,7 @@
 
 **Author:** Jack Morgan
 
-**Modified By:** Alasdair Smith
+**Modified By:** Alasdair Smith, Courtney Bracefield
 
 This interactive is used to create colours using RGB values.
 

--- a/csfieldguide/static/interactives/rgb-mixer/README.md
+++ b/csfieldguide/static/interactives/rgb-mixer/README.md
@@ -6,10 +6,12 @@
 
 This interactive is used to create colours using RGB values.
 
-## URL Parameter
+## URL Parameters
 
-- `hex=true|false (default=false)`: if `true`, sets the interactive to display values in hexadecimal (0 - FF) rather than decimal (0 - 255).
-- `mode=pixelmania`: Forces the display of values in hexadecimal only and displays the Pixelmania logo.
+- `hex=true|false (default=false)`: If `true`, sets the interactive to display values in hexadecimal (0 - FF) rather than decimal (0 - 255).
+- `hide-selector=true|false (default=false)`: If `true`, hides the option to choose between decimal and hexadecimal notations.
+- `pixelmania`: (for Pixelmania 2020) Displays the Pixelmania logo above the title.
+- `mode=pixelmania`: (for compatibility with permanently redirected links, **avoid using**) Sets `hex=true`, `hide-selector=true` and `pixelmania`.
 
 ## Required files
 

--- a/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
+++ b/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
@@ -25,15 +25,25 @@ RGB_Mixer.sliders = document.getElementsByClassName('interactive-rgb-mixer-slide
 RGB_Mixer.result = document.getElementById('interactive-rgb-mixer-result');
 
 $(document).ready(function () {
-  if (urlParameters.getUrlParameter('mode') == 'pixelmania') {
-    // hide radio buttons for switching numeral system
+
+  useHex = (urlParameters.getUrlParameter('hex') || 'false') == 'true';
+  if ((urlParameters.getUrlParameter('mode') || 'none') == 'pixelmania') {
+    // Certain URLs were permanently redirected to ?mode=pixelmania for pixelmania 2020
+    // so to avoid potential problems this parameter will remain in use
+    useHex = true;
     $("#numeral-system").addClass('d-none');
     $("#pixelmania-logo").removeClass("d-none");
-    useHex = true;
-  } else {
-    useHex = (urlParameters.getUrlParameter('hex') || 'false') == 'true';
-    $("input[id='hex-colour-code']").prop('checked', useHex);
-    $("input[id='dec-colour-code']").prop('checked', !useHex);
+  }
+  $("input[id='hex-colour-code']").prop('checked', useHex);
+  $("input[id='dec-colour-code']").prop('checked', !useHex);
+
+  if ((urlParameters.getUrlParameter('hide-selector') || 'false') == 'true') {
+    $("#numeral-system").addClass('d-none');
+  }
+
+  if (urlParameters.getUrlParameter('pixelmania')) {
+    // hide radio buttons for switching numeral system
+    $("#pixelmania-logo").removeClass("d-none");
   }
 
   for ( var i = 0; i < RGB_Mixer.sliders.length; i++ ) {

--- a/csfieldguide/templates/interactives/cmy-mixer.html
+++ b/csfieldguide/templates/interactives/cmy-mixer.html
@@ -4,11 +4,13 @@
 {% load static %}
 
 {% block html %}
-  <div id="interactive-cmy-mixer" class="mb-3 container-fluid">
+  <div id="interactive-cmy-mixer" class="my-3 container-fluid">
     <h3>{% trans "CMY Colour Mixer - Used by Printers" %}</h3>
-    <div id="interactive-cmy-mixer-container">
-      <div id="interactive-cmy-mixer-result"></div>
-        <div id="interactive-cmy-mixer-sliders">
+    <div id="interactive-cmy-mixer-container" class="row">
+      <div id="interactive-cmy-mixer-result" class="d-flex col-sm-12 col-md-3 col-lg-4 align-items-center justify-content-center ml-2">
+        <p id="interactive-cmy-mixer-colour-code" class="m-0 py-5"></p>
+      </div>
+        <div id="interactive-cmy-mixer-sliders" class="col-sm-12 col-md-8 col-lg-7 pt-3">
           <div>
             <div>{% trans '<strong>Cyan</strong> - Currently set to <input id="interactive-cmy-mixer-cyan-value" value=127 class="form-control w-auto d-inline" size="3">' %}</div>
             <div class="interactive-cmy-mixer-slider"></div>
@@ -23,7 +25,7 @@
           </div>
         </div>
     </div>
-    <div class="m-1">
+    <div id="numeral-system" class="m-1">
       <div class="form-check form-check-inline">
           <input class="form-check-input" type="radio" name="colourCode" value="dec" id="dec-colour-code" checked>
           <label class="form-check-label" for="dec-colour-code">{% trans "Decimal" %}</label>


### PR DESCRIPTION
- [x] Fix indentation style problems in PV
- [x] Fix style of RGB Mixer URL parameters
  - `pixelmania-2` redirects to a different url but the same functionality
  - The original `mode=pixelmania` option is deprecated but still works
  - New parameters: `hide-selector=true|false` for the rgb/hex radio options & `pixelmania` for the logo
- [x] Modernise CMY Mixer:
  - New URL parameter `hide-selector=true|false` for the rgb/hex radio options
    - No `pixelmania` parameter because it wasn't used for Pixelmania
  - Layout and css rules brought inline with RGB Mixer
  - Display of cmy colour code in colour box
     - There is no equivalent hex code for CMY so it is ~left blank~ also cmy colour code but using hex values

Resolves #1306 