### PR TITLE
Fix dockerignore folder names

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-csunplugged/build/*
-csunplugged/temp/*
-csunplugged/node_modules/*
+csfieldguide/build/*
+csfieldguide/temp/*
+csfieldguide/node_modules/*


### PR DESCRIPTION
This fixes a bug where dockerignore used the csunplugged filenames (it was probably a straight copy from CSU) rather than csfg ones.