### PR TITLE
Improve limitations for Algorithm Timer interactive

### DIFF
--- a/csfieldguide/static/interactives/algorithm-timer/README.md
+++ b/csfieldguide/static/interactives/algorithm-timer/README.md
@@ -1,5 +1,13 @@
 # Algorithm Timer Interactive
 
 **Author:** Courtney Bracefield
+**Modified by:** Alasdair Smith
 
 This interactive is created to demonstrate the running time for algorithms of different complexity.
+
+## Required files
+
+The interactive loads from a base website template which includes a JavaScript file containing jQuery, Bootstrap, and a few other utilities and polyfills.
+See `static/js/website.js` for a full list.
+It also uses [`Math.js`](https://mathjs.org/).
+Its licence is listed in `LICENCE-THIRD-PARTY`, with a full copy available in the `third-party-licences` directory.

--- a/csfieldguide/static/interactives/algorithm-timer/js/algorithm-timer.js
+++ b/csfieldguide/static/interactives/algorithm-timer/js/algorithm-timer.js
@@ -35,6 +35,8 @@ $(document).ready(function() {
   var speed = $('#speed').val();
   var processors = $('#processors').val();
   var timeUnits = $('input[name=time]:checked').prop('id');
+  startingComplexityText = COMPLEXITY_TEXT[complexity];
+  $('#complexity-chosen').html(startingComplexityText);
   if (inputIsValid(n, speed, processors, complexity)) {
     updateData();
   }
@@ -119,7 +121,7 @@ function calculateTimeTaken(complexity, resultForm, n, speed, processors, timeUn
   $('#processors').val(processors);
   speed = Mathjs.bignumber(speed);
   $('#speed').val(speed);
-  var steps = multiplyComplexity(n, complexity);
+  var steps = calculateSteps(n, complexity);
 
   var denominator = Mathjs.multiply(speed, processors);
   var timeTaken = Mathjs.divide(steps, denominator);
@@ -141,9 +143,8 @@ function calculateTimeTaken(complexity, resultForm, n, speed, processors, timeUn
 }
 
 
-/** Multiplies the value of n with the given complexity value.
- * Returns the number of steps required to run on n items */
-function multiplyComplexity(n, complexity) {
+/** Calculates the number of steps required, given the number of items and complexity of the algorithm. */
+function calculateSteps(n, complexity) {
   var steps;
   if (complexity == 'log') {
     steps = Math.ceil(Mathjs.log(n, 2));
@@ -183,7 +184,7 @@ function inputIsValid(n, speed, processors, complexity) {
   nItems = $('#n-items');
   nItemsInvalidMsg = $('#n-items-input-invalid');
   nItemsTooBigMsg = $('#n-items-input-too-big');
-  if (isNaN(n) || n < 1 || Mathjs.smaller(STEP_LIMIT, multiplyComplexity(n, complexity))) {
+  if (isNaN(n) || n < 1 || Mathjs.smaller(STEP_LIMIT, calculateSteps(n, complexity))) {
     nItems.addClass('is-invalid');
     isValid = false;
     if (isNaN(n) || n < 1) {

--- a/csfieldguide/static/interactives/algorithm-timer/js/algorithm-timer.js
+++ b/csfieldguide/static/interactives/algorithm-timer/js/algorithm-timer.js
@@ -246,6 +246,9 @@ function inputIsValid(n, speed, processors, complexity) {
   return isValid;
 }
 
+
+/** Returns true if the combination of n and complexity will yield a number
+ * too high to calculate safely, false otherwise */
 function nTooBigGivenComplexity(n, complexity) {
   // With a big enough complexity, high enough values for n
   // will freeze the interactive if we actually calculate it

--- a/csfieldguide/static/interactives/algorithm-timer/js/algorithm-timer.js
+++ b/csfieldguide/static/interactives/algorithm-timer/js/algorithm-timer.js
@@ -184,7 +184,7 @@ function inputIsValid(n, speed, processors, complexity) {
   nItems = $('#n-items');
   nItemsInvalidMsg = $('#n-items-input-invalid');
   nItemsTooBigMsg = $('#n-items-input-too-big');
-  if (isNaN(n) || n < 1 || Mathjs.smaller(STEP_LIMIT, calculateSteps(n, complexity))) {
+  if (isNaN(n) || n < 1 || nTooBigGivenComplexity(n, complexity)) {
     nItems.addClass('is-invalid');
     isValid = false;
     if (isNaN(n) || n < 1) {
@@ -244,4 +244,17 @@ function inputIsValid(n, speed, processors, complexity) {
   }
 
   return isValid;
+}
+
+function nTooBigGivenComplexity(n, complexity) {
+  // With a big enough complexity, high enough values for n
+  // will freeze the interactive if we actually calculate it
+  if (complexity in ['fourth-power', 'sixth-power']) {
+    return n > 1000000
+  } else if (complexity in ['exponential', 'factorial']) {
+    return n > 1000
+  }
+  //
+  
+  return Mathjs.smaller(STEP_LIMIT, calculateSteps(n, complexity))
 }

--- a/csfieldguide/templates/interactives/algorithm-timer.html
+++ b/csfieldguide/templates/interactives/algorithm-timer.html
@@ -86,21 +86,24 @@
           <label for="n-items" class="col-sm-6 col-form-label">{% trans "Number of items (n):" %}</label>
           <div class="col-sm-6 mt-1">
             <input class="form-control form-control-sm" id="n-items" value=10>
-            <div id="n-items-input-error" class="invalid-feedback d-none">{% trans "Please enter an integer between 1 and 1000 inclusive." %}</div>
+            <div id="n-items-input-invalid" class="invalid-feedback d-none">{% trans "Please enter a positive integer." %}</div>
+            <div id="n-items-input-too-big" class="invalid-feedback d-none">{% trans "This number is too big for the chosen complexity!" %}</div>
           </div>
         </div>
         <div class="form-group row">
           <label for="speed" class="col-sm-6 col-form-label">{% trans "Operations per second:" %}</label>
           <div class="col-sm-6 mt-1">
             <input class="form-control form-control-sm" id="speed" value=1>
-            <div id="speed-input-error" class='invalid-feedback d-none'>{% trans "Please enter a positive number no higher than 1000000." %}</div>
+            <div id="speed-input-invalid" class='invalid-feedback d-none'>{% trans "Please enter a positive number." %}</div>
+            <div id="speed-input-too-big" class='invalid-feedback d-none'>{% trans "This number is too big!" %}</div>
           </div>
         </div>
         <div class="form-group row">
           <label for="processors" class="col-sm-6 col-form-label">{% trans "Processors:" %}</label>
           <div class="col-sm-6 mt-1">
             <input class="form-control form-control-sm" id="processors" value=1>
-            <div id="processors-input-error" class='invalid-feedback d-none'>{% trans "Please enter an integer between 1 and 1000 inclusive." %}</div>
+            <div id="processors-input-invalid" class='invalid-feedback d-none'>{% trans "Please enter a positive integer." %}</div>
+            <div id="processors-input-too-big" class='invalid-feedback d-none'>{% trans "This number is too big!" %}</div>
           </div>
         </div>
 


### PR DESCRIPTION
Resolves #1332 

- [x] Limit the number of items `n` based on the algorithm complexity:
    - If the number of steps required (based on `n` & the complexity) is greater than `10^32`, the calculation won't be made
- [x] increase limit on the number of processors, and number of operations per second:
    - New limit is `10^16` processors/operations per second
- [x] Add second warning message for each input box
   - One for an invalid number, one for a number that's too high