### PR TITLE
Add percent-encoder to cfg-parsing-challenge

### DIFF
--- a/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
@@ -11,7 +11,8 @@ The interactive has the ability to do any grammar via use of the URL parameters.
 
 ### Basic Parameters
 
-- `productions=str`: Set the grammar productions that can be used. Lone integers, as well as strings beginning and ending with an inverted comma, are interpreted as terminals. An example of the correct syntax using the default grammar can be found below.
+- `productions=str`: Set the grammar productions that can be used. Lone integers, as well as strings beginning and ending with an inverted comma, are interpreted as terminals.
+An example of the correct syntax using the default grammar can be found below.
 - `examples=str|str|str|...`: Set the examples that can be selected by the `Next` generator option. Examples will be cycled through in the order given.
 - `hide-generator=[true|false] (default: false)`: If `true`, remove the built-in equation generator (`Random` & `Simple`).
 
@@ -20,17 +21,18 @@ The interactive has the ability to do any grammar via use of the URL parameters.
 These parameters allow more control over the built-in equation generator.
 The defaults work well for the default productions, but in most situations it is recommended that `recursion-depth` is set higher than the default and `retry-if-fail` is set to `true`.
 
-- `recursion-depth=int (default: 3)`: Set the maximum recursion depth for the built-in equation generator (`Random`). If this or `retry-if-fail` is set then the option to generate with depth 1 (`Simple`) is removed.
-- `retry-if-fail=[true|false] (default: false)`: If `true`, the built-in equation generator will restart if it reaches the maximum recursion depth but nonterminals remain in the equation. After 10 tries the generator will quit with an error message. Otherwise if the generator reaches the maximum depth, it will replace all remaining nonterminals with random terminals from `terminals`, even if such replacements aren't valid.
+- `recursion-depth=int (default: 3)`: Set the maximum recursion depth for the built-in equation generator (`Random`).
+If this or `retry-if-fail` is set then the option to generate with depth 1 (`Simple`) is removed.
+- `retry-if-fail=[true|false] (default: false)`: If `true`, the built-in equation generator will restart if it reaches the maximum recursion depth but nonterminals remain in the equation.
+After 10 tries the generator will quit with an error message. Otherwise if the generator reaches the maximum depth, it will replace all remaining nonterminals with random terminals from `terminals`, even if such replacements aren't valid.
 - `terminals=str|str|str|... (default: 0-9)`: Set the terminals that can be selected from by the built-in equation generator if the maximum recursion depth is reached. If `retry-if-fail` is `true` then this parameter will have no effect.
 
 ### URL Parameter Limitations
 
-- If a production replaces a nonterminal with one integer, that integer will
-be interpreted as a terminal with or without the inverted commas.
+- If a production replaces a nonterminal with one integer, that integer will be interpreted as a terminal with or without the inverted commas.
 This allows a shorthand syntax where the inverted commas can be left out.
-- Parameter syntax characters, including spaces and (`:`,`'`,`|`,`;`), are always interpreted as such,
-so problems will occur if they are attempted to be used as part of the grammar productions.
+- Parameter syntax characters, including spaces and (`:`,`'`,`|`,`;`), are always interpreted as such, so problems will occur if they are attempted to be used as part of the grammar productions.
+- The ampisand (&) is used to separate url parameters so will also cause problems if used in grammar productions.
 
 ### URL Productions Example
 

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
@@ -3,7 +3,7 @@
 **Author:** Alasdair Smith
 
 This interactive demonstrates a context-free grammar (CFG) by allowing a user to use it to build a mathematical equation (default behaviour) or sentences.
-The interactive has the ability to do any grammar via use of the URL parameters.
+The interactive can demonstrate most grammars via use of the URL parameters.
 
 ## URL Parameters
 
@@ -29,10 +29,8 @@ After 10 tries the generator will quit with an error message. Otherwise if the g
 
 ### URL Parameter Limitations
 
-- If a production replaces a nonterminal with one integer, that integer will be interpreted as a terminal with or without the inverted commas.
-This allows a shorthand syntax where the inverted commas can be left out.
 - Parameter syntax characters, including spaces and (`:`,`'`,`|`,`;`), are always interpreted as such, so problems will occur if they are attempted to be used as part of the grammar productions.
-- The ampisand (&) is used to separate url parameters so will also cause problems if used in grammar productions.
+- The ampisand (`&`) is used to separate url parameters so will also cause problems if used in grammar productions.
 
 ### URL Productions Example
 
@@ -54,13 +52,13 @@ D
   ;
 ```
 
-When used as a URL parameter, including the shorthand for lone integers:
+When used as a URL parameter:
 
-`url?productions=E:N|E '+' E|E '*' E|'-' E|'(' E ')';N:0|1|2|3|4|5|6|7|8|9;`
+`url?productions=E:N|E '+' E|E '*' E|'-' E|'(' E ')';N:'0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9';`
 
 With percent encoding:
 
-`url?productions=E%3aN%7cE%20%27%2b%27%20E%7cE%20%27%2a%27%20E%7c%27-%27%20E%7c%27%28%27%20E%20%27%29%27%3bN%3a0%7c1%7c2%7c3%7c4%7c5%7c6%7c7%7c8%7c9%3b`
+`url?productions=E%3aN%7cE%20%27%2b%27%20E%7cE%20%27%2a%27%20E%7c%27-%27%20E%7c%27%28%27%20E%20%27%29%27%3bN%3a%270%27%7c%271%27%7c%272%27%7c%273%27%7c%274%27%7c%275%27%7c%276%27%7c%277%27%7c%278%27%7c%279%27%3b`
 
 ## Required files
 

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
@@ -30,7 +30,7 @@ After 10 tries the generator will quit with an error message. Otherwise if the g
 ### URL Parameter Limitations
 
 - Parameter syntax characters, including spaces and (`:`,`'`,`|`,`;`), are always interpreted as such, so problems will occur if they are attempted to be used as part of the grammar productions.
-- The ampisand (`&`) is used to separate url parameters so will also cause problems if used in grammar productions.
+- The ampersand (`&`) is used to separate url parameters so will also cause problems if used in grammar productions.
 
 ### URL Productions Example
 

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
@@ -145,7 +145,7 @@ function parseUrlParameters() {
  * Parses the given string to form a dictionary of grammar productions.
  * 
  * e.g. the default productions could be parsed from:
- * E : N | E '+' E | E '*' E | '-' E | '(' E ')' ; N : '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;
+ * E:N|E '+' E|E '*' E|'-' E|'(' E ')'; N:'0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9';
  */
 function decodeGrammar(productionString) {
   var duo, nonterminal, replacementString;
@@ -172,7 +172,7 @@ function decodeGrammar(productionString) {
 
 /**
  * Returns a list of production replacements in the format expected by this program.
- * If every replacement is an integer, returns a list of elements rather than
+ * If every replacement is an integer terminal, returns a list of elements rather than
  * a list of lists
  */
 function interpretReplacementStrings(replacementStrings) {
@@ -181,11 +181,10 @@ function interpretReplacementStrings(replacementStrings) {
   var replacementUnits;
   for (let i=0; i<replacementStrings.length; i++) {
     replacementUnits = replacementStrings[i].trim().split(' ');
-    let firstUnit = replacementUnits[0].replace(/^\'+|\'+$/g, '');
-    if (replacementUnits.length == 1 && !isNaN(firstUnit)
-    && parseInt(firstUnit) == parseFloat(firstUnit)) {
+    let firstUnit = replacementUnits[0];
+    if (replacementUnits.length == 1 && firstUnit.match(/^\'\d+\'$/g)) {
       // A full list of integer terminals is interpreted differently
-      replacements.push(parseInt(firstUnit));
+      replacements.push(parseInt(firstUnit.replace(/^\'+|\'+$/g, '')));
     } else {
       replacements.push(replacementUnits);
     }

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
@@ -62,6 +62,8 @@ $(document).ready(function() {
     setGenerator('from-preset');
   })
   $('#undo-button').on('click', undo);
+  $('#cfg-grammar-link-button').on('click', getLink);
+  $('#cfg-default-link-button').on('click', resetLink);
   $('#undo-button').prop('disabled', true);
   $('#cfg-target').change(testMatchingEquations);
   if (examples_.length) {
@@ -73,6 +75,8 @@ $(document).ready(function() {
   } else {
     $('#cfg-target').val(randomExpression(initialNonterminal_, productions_, RECURSIONDEPTH_SIMPLE));
   }
+  $('#cfg-grammar-input').val('');
+  getLink();
   reapplyNonterminalClickEvent();
   //https://stackoverflow.com/a/3028037
   $(document).click(function(event) { 
@@ -556,4 +560,41 @@ function recursiveRandomExpression(replaced, productions, maxDepth, doRetry, ter
     }
   }
   return returnString;
+}
+
+/******************************************************************************/
+// FUNCTIONS FOR THE TEACHER MODE PRODUCTIONS SETTER //
+/******************************************************************************/
+
+/**
+ * Sets the link in the teacher-mode productions setter to the base url of the interactive
+ */
+function resetLink() {
+  var instruction = gettext("This link will open the default version of this interactive:");
+  var link = window.location.href.split('?', 1)[0].replace(/^\/+|\/+$/g, '');
+  $("#cfg-grammar-link").html(`${instruction}<br><a href=${link}>${link}</a>`);
+}
+
+/**
+ * Sets the link in the teacher-mode productions setter based on the productions submitted
+ */
+function getLink() {
+  var instruction = gettext("This link will open the interactive with your set productions:");
+  var productions = $("#cfg-grammar-input").val().trim();
+  if (productions.length <= 0) {
+    $("#cfg-grammar-link").html("");
+    return;
+  }
+  var productionsParameter = percentEncode(productions.replace(/\n/g, ' '));
+  var otherParameters = "&hide-generator=true";
+  var basePath = window.location.href.split('?', 1)[0];
+  var fullUrl = basePath + "?productions=" + productionsParameter + otherParameters;
+  $("#cfg-grammar-link").html(`${instruction}<br><a href=${fullUrl}>${fullUrl}</a>`);
+}
+
+/**
+ * Returns the given string percent-encoded
+ */
+function percentEncode(string) {
+  return encodeURIComponent(string);
 }

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/scss/cfg-parsing-challenge.scss
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/scss/cfg-parsing-challenge.scss
@@ -53,3 +53,14 @@
   font-family: sans-serif;
   text-align: center;
 }
+
+#cfg-example-productions {
+  font-family: monospace;
+  background-color: #ececec;
+  border-radius: 5px;
+}
+
+#cfg-grammar-input {
+  font-family: monospace;
+  width: 100%;
+}

--- a/csfieldguide/templates/interactives/cfg-parsing-challenge.html
+++ b/csfieldguide/templates/interactives/cfg-parsing-challenge.html
@@ -4,6 +4,64 @@
 {% load static %}
 
 {% block html %}
+<div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-hidden="true" id="grammar-builder">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">{% trans "Teacher mode grammar builder" %}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>{% trans "Use this window to configure the interactive with your own set of grammar productions." %}</p>
+        <div class="container-fluid">
+          <div class="row d-flex justify-content-between">
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#instructions-collapse" aria-expanded="false" aria-controls="instructions-collapse">
+              {% trans "Toggle instructions" %}
+            </button>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#example-collapse" aria-expanded="false" aria-controls="example-collapse">
+              {% trans "Toggle example" %}
+            </button>
+          </div>
+          <div class="row py-2">
+            <div class="collapse" id="instructions-collapse">
+              <div class="card card-body">
+                <li>{% trans "The syntax is a simplified YACC syntax." %}</li>
+                <li>{% trans "Begin each line with a nonterminal and colon (:), and end it with a semicolon (;)." %}</li>
+                <li>{% trans "Between the colon and semicolon, list replacements for the nonterminal separated by vertical bars (|)." %}</li>
+                <li>{% trans "An integer or a string enclosed in inverted commas (') is interpreted as a terminal." %}</li>
+                <li>{% trans "Separate nonterminals from each other, and terminals from nonterminals, with spaces." %}</li>
+                <li>{% trans "Spaces, colons, semicolons, inverted commas, and vertical bars are all reserved for defining the productions and should not be used in the productions themselves." %}</li>
+                <li>{% trans "Ampisands (&) are reserved for interpreting the url and should not be used either." %}</li>
+              </div>
+            </div>
+            <div class="collapse" id="example-collapse">
+              <div class="card card-body">
+                <p>{% trans "The default grammar productions can be obtained from:" %}</p>
+                <div class="p-2" id="cfg-example-productions">
+                  E:N|E '+' E|E '*' E| '-' E|'(' E ')';
+                  N:0|1|2|3|4|5|6|7|8|9;
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row py-2">
+            <textarea class="form-control" id="cfg-grammar-input" placeholder="{% trans 'Enter your productions here.' %}"></textarea>
+          </div>
+          <div class="row">
+            <button type="button" class="btn btn-primary" id="cfg-grammar-link-button">{% trans "Get link" %}</button>
+            <button type="button" class="btn btn-secondary mx-2" id="cfg-default-link-button">{% trans "Get link to default" %}</button>
+            <p class="pt-2" id="cfg-grammar-link"></p>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Close" %}</button>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="container">
   <h2 class="text-center mt-3">{% trans "Context-free Grammar Parsing Challenge" %}</h2>
   <div class="row">
@@ -35,12 +93,19 @@
         <button type="button" class="btn btn-danger btn-sm m-1 float-right" id="reset-button">{% trans "Reset" %}</button>
       </div>
     </div>
-    <div class="col-12 col-md-3 d-flex justify-content-center">
+    <div class="col-12 col-md-3">
       <div class="py-2">
-        <table class="m-2" id="productions-table-container">
+        <table class="my-2 mx-auto" id="productions-table-container">
           <tbody id="productions-table"></tbody>
         </table>
       </div>
+      {% if teacher_mode %}
+      <div class="row">
+        <button type="button" class="btn btn-primary navbar-teacher-mode mx-auto" data-toggle="modal" data-target="#grammar-builder">
+          {% trans "New productions" %}
+        </button>
+      </div>
+      {% endif %}
     </div>
   </div>
   <div id="selection-popup"></div>

--- a/csfieldguide/templates/interactives/cfg-parsing-challenge.html
+++ b/csfieldguide/templates/interactives/cfg-parsing-challenge.html
@@ -30,9 +30,9 @@
                 <li>{% trans "The syntax is a simplified YACC syntax." %}</li>
                 <li>{% trans "Begin each line with a nonterminal and colon (:), and end it with a semicolon (;)." %}</li>
                 <li>{% trans "Between the colon and semicolon, list replacements for the nonterminal separated by vertical bars (|)." %}</li>
-                <li>{% trans "An integer or a string enclosed in inverted commas (') is interpreted as a terminal." %}</li>
+                <li>{% trans "Enclose terminals with inverted commas (')." %}</li>
                 <li>{% trans "Separate nonterminals from each other, and terminals from nonterminals, with spaces." %}</li>
-                <li>{% trans "Spaces, colons, semicolons, inverted commas, and vertical bars are all reserved for defining the productions and should not be used in the productions themselves." %}</li>
+                <li>{% trans "Spaces, colons, semicolons, inverted commas and vertical bars are all reserved for defining the productions and should not be used in the productions themselves." %}</li>
                 <li>{% trans "Ampisands (&) are reserved for interpreting the url and should not be used either." %}</li>
               </div>
             </div>
@@ -40,8 +40,8 @@
               <div class="card card-body">
                 <p>{% trans "The default grammar productions can be obtained from:" %}</p>
                 <div class="p-2" id="cfg-example-productions">
-                  E:N|E '+' E|E '*' E| '-' E|'(' E ')';
-                  N:0|1|2|3|4|5|6|7|8|9;
+                  E:N|E '+' E|E '*' E|'-' E|'(' E ')';
+                  N:'0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9';
                 </div>
               </div>
             </div>

--- a/csfieldguide/templates/interactives/cfg-parsing-challenge.html
+++ b/csfieldguide/templates/interactives/cfg-parsing-challenge.html
@@ -33,7 +33,7 @@
                 <li>{% trans "Enclose terminals with inverted commas (')." %}</li>
                 <li>{% trans "Separate nonterminals from each other, and terminals from nonterminals, with spaces." %}</li>
                 <li>{% trans "Spaces, colons, semicolons, inverted commas and vertical bars are all reserved for defining the productions and should not be used in the productions themselves." %}</li>
-                <li>{% trans "Ampisands (&) are reserved for interpreting the url and should not be used either." %}</li>
+                <li>{% trans "Ampersands (&) are reserved for interpreting the url and should not be used either." %}</li>
               </div>
             </div>
             <div class="collapse" id="example-collapse">


### PR DESCRIPTION
Adds a teacher-mode-only button that opens a modal which the user can use to set the grammar productions in the interactive.

Since there's no button to switch to teacher mode on the interactive page itself, the user needs to be in teacher mode before opening the interactive, or to switch to teacher mode in another tab and then refresh the interactive page, to see this button.

The instructions button toggles a dropdown of a few key bullet points about syntax, the example one drops down a representation of the default productions.

Once the grammar productions have been set, the user can obtain a link, adequately percent-encoded, to the interactive with the given productions. This link also hides the generator

The link generated can also leave the boundary of the modal, `word-wrap: break-word` doesn't help so not sure how to proceed - scrollbar?

**Edit**: *Also removed the ambiguity of edge cases in URL grammar productions regarding numbers. Whereas there was a shortcut for lone integers previously; all terminals must now be enclosed in inverted commas.*

![image](https://user-images.githubusercontent.com/25916475/107593565-7df2c380-6c74-11eb-8401-798493051cb0.png)

![image](https://user-images.githubusercontent.com/25916475/107593052-52230e00-6c73-11eb-9418-9cb847e93c14.png)
