### PR TITLE
Release 3.8.2

### DIFF
--- a/csfieldguide/config/__init__.py
+++ b/csfieldguide/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "3.8.1"
+__version__ = "3.8.2"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,7 @@ services:
                 condition: on-failure
             labels:
                 - "traefik.enable=true"
-                - "traefik.docker.network=uccser-dev-public"
+                - "traefik.docker.network=uccser-public"
                 - "traefik.http.services.cs-field-guide-django.loadbalancer.server.port=8000"
                 - "traefik.http.routers.cs-field-guide-django.service=cs-field-guide-django"
                 - "traefik.http.routers.cs-field-guide-django.rule=Host(`${CS_FIELD_GUIDE_DOMAIN}`)"
@@ -41,7 +41,7 @@ services:
             - cs-field-guide_postgres_user
             - cs-field-guide_postgres_password
         networks:
-            - uccser-dev-public
+            - uccser-public
             - backend
 
     postgres:
@@ -108,7 +108,7 @@ secrets:
         external: true
 
 networks:
-    uccser-dev-public:
+    uccser-public:
         external: true
     backend:
         driver: overlay

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,15 @@ All notable changes to this project will be documented in this file.
 We have listed major changes for each release below.
 `All downloads are available on GitHub <https://github.com/uccser/cs-field-guide/releases/>`__
 
+3.8.2
+==============================================================================
+
+**Release date:** 6th September 2021
+
+**Changelog:**
+
+- Modify network name for production deployments.
+
 3.8.1
 ==============================================================================
 


### PR DESCRIPTION
**Release date:** 6th September 2021

**Changelog:**

- Modify network name for production deployments.