### PR TITLE
Further changes to CFG interactive

### DIFF
--- a/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
@@ -11,7 +11,7 @@ The interactive can demonstrate most grammars via URL parameters.
 
 This interactive can be configured by appending various parameters to the default URL.
 To do this, add a question mark (`?`) after the last `/` in the URL, then each parameter separated by ampersands (`&`).
-For this interactive, each parameter is in the form `keyword=value`, where each `keyword` is an option to be changed and `value` is what that option should be set to.
+For this interactive, each parameter is in the form `keyword=value`, where `keyword` is an option to be changed and `value` is what that option should be set to.
 For example:
 
 - The URL `[...]/cfg-parsing-challenge/` could be changed to `[...]/cfg-parsing-challenge/?hide-generator=true&examples=1+1|2+3+4`
@@ -26,7 +26,7 @@ For example:
 Examples will be cycled through in the order given.
 - `productions=str`: Set the grammar productions that can be used.
 An example of the correct syntax using the default grammar can be found below.
-  - When setting your own productions, it is recommended that you also use either the `recursion-depth` or `hide-generator` parameters.
+  - When setting your own productions, it is recommended that you also use either the `recursion-depth` or `hide-generator` parameter.
 
 The built-in equation generator works by following productions at random from the initial non-terminal - essentially building a parse tree - until there are no non-terminals left in the equation.
 In certain grammars, the parse tree could continue indefinitely, so the generator is forced to stop a certain number of branches down the tree:

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
@@ -1,6 +1,6 @@
 # CFG Parsing Challenge Interactive
 
-**Author:** Alasdair Smith
+**Author:** Alasdair Smith  
 **Modified by:** Jack Morgan, Alasdair Smith
 
 This interactive demonstrates a context-free grammar (CFG) by allowing a user to use it to build a mathematical equation (default behaviour) or sentences.
@@ -18,29 +18,22 @@ For example:
 
 **Note**: It is recommended that parameter values have all non-unreserved characters [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
 
-### Basic Parameters
+### Parameters
 
-- `editable-target=[true|false] (default: false)`: If `true`, allow the target equation to be edited via keyboard input.
+- `editable-target=[true|false] (default: false)`: If `true`, allow the target equation field to be edited.
 - `hide-builder=[true|false] (default: false)`: If `true`, hide the button that would allow the user to set their own productions.
-- `hide-generator=[true|false] (default: false)`: If `true`, disable the built-in equation generator (options `Random` & `Simple`).
-- `examples=str|str|str|...`: Set the examples that can be selected by the `Next` generator option.
+- `examples=str|str|str|...`: Enable the `Next` option, and set the examples that can be selected by it.
 Examples will be cycled through in the order given.
 - `productions=str`: Set the grammar productions that can be used.
 An example of the correct syntax using the default grammar can be found below.
-  - The built-in equation generator is configured as it is because it works well with the default productions.
-  When setting your own productions, it is highly recommended that you investigate the Advanced Parameters section of this README, or to disable the generator entirely using the `hide-generator` parameter.
-
-### Advanced Parameters
+  - When setting your own productions, it is recommended that you also use either the `recursion-depth` or `hide-generator` parameters.
 
 The built-in equation generator works by following productions at random from the initial non-terminal - essentially building a parse tree - until there are no non-terminals left in the equation.
-In certain grammars, the parse tree could continue indefinitely, so the generator is forced to stop a certain number of branches down the tree.
+In certain grammars, the parse tree could continue indefinitely, so the generator is forced to stop a certain number of branches down the tree:
 
-The following parameters allow more control over the generator, notably the number of branches down that the generator will attempt (the `recursion-depth`), as well as what it will do if it reaches this depth and non-terminals remain in the equation.
-
-The defaults work well for the default productions because there is a direct path from every non-terminal to every terminal.
-
-- `recursion-depth=int (default: 4)`: Set the maximum recursion depth for the built-in equation generator (`Random`).
-If this  is set then the option to generate with depth 1 (`Simple`) is removed.
+- `hide-generator=[true|false] (default: false)`: If `true`, disable the built-in equation generator (options `Random` & `Simple`).
+- `recursion-depth=int (default: 5)`: Set the maximum depth of the parse tree for the built-in equation generator (`Random`).
+If this is set then the option to generate with depth 3 (`Simple`) is removed.
 After 100 tries the generator will quit with an error message.
 
 ### URL Parameter Limitations

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
@@ -1,6 +1,7 @@
 # CFG Parsing Challenge Interactive
 
 **Author:** Alasdair Smith
+**Modified by:** Jack Morgan, Alasdair Smith
 
 This interactive demonstrates a context-free grammar (CFG) by allowing a user to use it to build a mathematical equation (default behaviour) or sentences.
 The user can also obtain a link to the interactive with their own productions through a simple interface.
@@ -15,10 +16,11 @@ For example:
 
 - The URL `[...]/cfg-parsing-challenge/` could be changed to `[...]/cfg-parsing-challenge/?hide-generator=true&examples=1+1|2+3+4`
 
-**Note**: It is recommended, though often not necessary, that parameter values have all non-unreserved characters [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
+**Note**: It is recommended that parameter values have all non-unreserved characters [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
 
 ### Basic Parameters
 
+- `editable-target=[true|false] (default: false)`: If `true`, allow the target equation to be edited via keyboard input.
 - `hide-builder=[true|false] (default: false)`: If `true`, hide the button that would allow the user to set their own productions.
 - `hide-generator=[true|false] (default: false)`: If `true`, disable the built-in equation generator (options `Random` & `Simple`).
 - `examples=str|str|str|...`: Set the examples that can be selected by the `Next` generator option.

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/README.md
@@ -3,7 +3,7 @@
 **Author:** Alasdair Smith  
 **Modified by:** Jack Morgan, Alasdair Smith
 
-This interactive demonstrates a context-free grammar (CFG) by allowing a user to use it to build a mathematical equation (default behaviour) or sentences.
+This interactive demonstrates a context-free grammar (CFG) by allowing a user to use it to build a mathematical expression (default behaviour) or sentences.
 The user can also obtain a link to the interactive with their own productions through a simple interface.
 The interactive can demonstrate most grammars via URL parameters.
 
@@ -20,7 +20,7 @@ For example:
 
 ### Parameters
 
-- `editable-target=[true|false] (default: false)`: If `true`, allow the target equation field to be edited.
+- `editable-target=[true|false] (default: false)`: If `true`, allow the target field to be edited.
 - `hide-builder=[true|false] (default: false)`: If `true`, hide the button that would allow the user to set their own productions.
 - `examples=str|str|str|...`: Enable the `Next` option, and set the examples that can be selected by it.
 Examples will be cycled through in the order given.
@@ -28,13 +28,12 @@ Examples will be cycled through in the order given.
 An example of the correct syntax using the default grammar can be found below.
   - When setting your own productions, it is recommended that you also use either the `recursion-depth` or `hide-generator` parameter.
 
-The built-in equation generator works by following productions at random from the initial non-terminal - essentially building a parse tree - until there are no non-terminals left in the equation.
+The built-in expression generator follows productions (almost) at random from the initial non-terminal - essentially following a parse tree - until there are no non-terminals left in the expression.
 In certain grammars, the parse tree could continue indefinitely, so the generator is forced to stop a certain number of branches down the tree:
 
-- `hide-generator=[true|false] (default: false)`: If `true`, disable the built-in equation generator (options `Random` & `Simple`).
-- `recursion-depth=int (default: 5)`: Set the maximum depth of the parse tree for the built-in equation generator (`Random`).
+- `hide-generator=[true|false] (default: false)`: If `true`, disable the built-in expression generator (options `Random` & `Simple`).
+- `recursion-depth=int (default: 5)`: Set the maximum depth of the parse tree for the built-in expression generator (`Random`).
 If this is set then the option to generate with depth 3 (`Simple`) is removed.
-After 100 tries the generator will quit with an error message.
 
 ### URL Parameter Limitations
 

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
@@ -41,7 +41,14 @@ $(document).ready(function() {
 
   // Setup events
   $('#generate-button').on('click', function(event) {
-    $('#cfg-target').val(generateTarget(event.target));
+    let newTarget = generateTarget(event.target);
+    let t=0;
+    // Avoid (but don't prevent) the new target expression being the same as the old one
+    while (newTarget == $('#cfg-target').val() && t<RECURSIONDEPTH_MAX) {
+      newTarget = generateTarget(event.target);
+      t++;
+    }
+    $('#cfg-target').val(newTarget);
     resetEquation();
   });
   $('#reset-button').on('click', function() {

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
@@ -7,14 +7,14 @@ var urlParameters = require('../../../js/third-party/url-parameters.js');
 * A production with only terminals can be a list of elements rather than a list of lists
 */
 const DEFAULT_PRODUCTIONS = {
-    "E": [
-        ["N"],
-        ["E", "'+'", "E"],
-        ["E", "'*'", "E"],
-        ["'-'", "E"],
-        ["'('", "E", "')'"],
-    ],
-    "N": [0,1,2,3,4,5,6,7,8,9]
+  "E": [
+    ["N"],
+    ["E", "'+'", "E"],
+    ["E", "'*'", "E"],
+    ["'-'", "E"],
+    ["'('", "E", "')'"],
+  ],
+  "N": [0,1,2,3,4,5,6,7,8,9]
 };
 
 const RECURSIONDEPTH_SIMPLE = 2;
@@ -32,71 +32,71 @@ var hideGenerator_ = false;
 var recursionDepth_ = RECURSIONDEPTH_DEFAULT;
 
 $(document).ready(function() {
-    // Setup global variables
-    historyListElem_ = document.getElementById('history-list');
-    parseUrlParameters();
+  // Setup global variables
+  historyListElem_ = document.getElementById('history-list');
+  parseUrlParameters();
 
-    // Setup events
-    $('#generate-button').on('click', function(event) {
-        $('#cfg-target').val(generateTarget(event.target));
-        resetEquation();
-    });
-    $('#reset-button').on('click', function() {
-        resetEquation();
-    });
-    $('#set-g-random').on('click', function () {
-        setGenerator('random');
-    })
-    $('#set-g-random-simple').on('click', function () {
-        setGenerator('random-simple');
-    })
-    $('#set-g-from-preset').on('click', function () {
-        setGenerator('from-preset');
-    })
-    $('#undo-button').on('click', undo);
-    $('#cfg-grammar-link-button').on('click', getLink);
-    $('#cfg-default-link-button').on('click', resetLink);
-    $("#examples-checkbox").change(toggleExamplesWindow).prop('checked', false);
-    //https://stackoverflow.com/a/3028037
-    $(document).click(function (event) {
-        var $target = $(event.target);
-        if (!$target.closest('.nonterminal').length &&
-            !$target.closest('#selection-popup').length &&
-            $('#selection-popup').is(':visible')) {
-            $('#selection-popup').hide();
-            $activeNonterminal_ = null;
-        }
-    });
-
-    // Setup interface
+  // Setup events
+  $('#generate-button').on('click', function(event) {
+    $('#cfg-target').val(generateTarget(event.target));
     resetEquation();
-    fillProductionsWindow(productions_);
-    toggleExamplesWindow();
-    $('#cfg-target').change(testMatchingEquations);
-
-    if (examples_.length) {
-        $('#cfg-target').val(examples_[0]);
-    } else if (hideGenerator_) {
-        $('#cfg-target').val("");
-    } else {
-        $('#cfg-target').val(randomExpression(initialNonterminal_, productions_, recursionDepth_));
+  });
+  $('#reset-button').on('click', function() {
+    resetEquation();
+  });
+  $('#set-g-random').on('click', function () {
+    setGenerator('random');
+  })
+  $('#set-g-random-simple').on('click', function () {
+    setGenerator('random-simple');
+  })
+  $('#set-g-from-preset').on('click', function () {
+    setGenerator('from-preset');
+  })
+  $('#undo-button').on('click', undo);
+  $('#cfg-grammar-link-button').on('click', getLink);
+  $('#cfg-default-link-button').on('click', resetLink);
+  $("#examples-checkbox").change(toggleExamplesWindow).prop('checked', false);
+  //https://stackoverflow.com/a/3028037
+  $(document).click(function (event) {
+    var $target = $(event.target);
+    if (!$target.closest('.nonterminal').length &&
+      !$target.closest('#selection-popup').length &&
+      $('#selection-popup').is(':visible')) {
+      $('#selection-popup').hide();
+      $activeNonterminal_ = null;
     }
-    $('#cfg-grammar-input').val('');
-    getLink();
+  });
+
+  // Setup interface
+  resetEquation();
+  fillProductionsWindow(productions_);
+  toggleExamplesWindow();
+  $('#cfg-target').change(testMatchingEquations);
+
+  if (examples_.length) {
+    $('#cfg-target').val(examples_[0]);
+  } else if (hideGenerator_) {
+    $('#cfg-target').val("");
+  } else {
+    $('#cfg-target').val(randomExpression(initialNonterminal_, productions_, recursionDepth_));
+  }
+  $('#cfg-grammar-input').val('');
+  getLink();
 });
 
 /**
 * Resets the equation being constructed by the user to solely the original non-terminal
 */
 function resetEquation() {
-    let initial_html = `<span class="nonterminal">${initialNonterminal_}</span>`;
-    $('#cfg-equation').html(initial_html);
-    reapplyNonterminalClickEvent();
-    testMatchingEquations();
-    historyStack_ = [];
-    historyListElem_.innerHTML = '';
-    addHistoryElement(initial_html, null);
-    $('#undo-button').prop('disabled', true);
+  let initial_html = `<span class="nonterminal">${initialNonterminal_}</span>`;
+  $('#cfg-equation').html(initial_html);
+  reapplyNonterminalClickEvent();
+  testMatchingEquations();
+  historyStack_ = [];
+  historyListElem_.innerHTML = '';
+  addHistoryElement(initial_html, null);
+  $('#undo-button').prop('disabled', true);
 }
 
 /******************************************************************************/
@@ -107,44 +107,44 @@ function resetEquation() {
 * Interprets the given URL parameters and prepares the interactive accordingly
 */
 function parseUrlParameters() {
-    if (urlParameters.getUrlParameter('hide-builder') == 'true') {
-        $('#grammar-builder-button').hide();
-    }
-    var grammar = urlParameters.getUrlParameter('productions');
-    var examples = urlParameters.getUrlParameter('examples');
-    var recursionDepth = urlParameters.getUrlParameter('recursion-depth');
-    hideGenerator_ = urlParameters.getUrlParameter('hide-generator') == 'true';
+  if (urlParameters.getUrlParameter('hide-builder') == 'true') {
+    $('#grammar-builder-button').hide();
+  }
+  var grammar = urlParameters.getUrlParameter('productions');
+  var examples = urlParameters.getUrlParameter('examples');
+  var recursionDepth = urlParameters.getUrlParameter('recursion-depth');
+  hideGenerator_ = urlParameters.getUrlParameter('hide-generator') == 'true';
 
-    if (grammar) {
-        productions_ = decodeGrammar(grammar);
+  if (grammar) {
+    productions_ = decodeGrammar(grammar);
+  }
+  if (examples) {
+    examples = examples.split('|');
+    for (let i=0; i<examples.length; i++) {
+      examples[i] = examples[i].trim();
     }
+    examples_ = examples;
+  } else {
+    $('#set-g-from-preset').hide();
+  }
+  if (recursionDepth && parseInt(recursionDepth) > 0) {
+    recursionDepth_ = parseInt(recursionDepth);
+  }
+  if (hideGenerator_) {
     if (examples) {
-        examples = examples.split('|');
-        for (let i=0; i<examples.length; i++) {
-            examples[i] = examples[i].trim();
-        }
-        examples_ = examples;
+      setGenerator('from-preset');
+      $('#set-g-random').hide();
+      $('#set-g-random-simple').hide();
+      $('#generate-dropdown').hide();
     } else {
-        $('#set-g-from-preset').hide();
+      $('#generator-buttons').hide();
     }
-    if (recursionDepth && parseInt(recursionDepth) > 0) {
-        recursionDepth_ = parseInt(recursionDepth);
+  } else if (recursionDepth) {
+    $('#set-g-random-simple').hide();
+    if (!examples) {
+      $('#set-g-from-preset').hide();
     }
-    if (hideGenerator_) {
-        if (examples) {
-            setGenerator('from-preset');
-            $('#set-g-random').hide();
-            $('#set-g-random-simple').hide();
-            $('#generate-dropdown').hide();
-        } else {
-            $('#generator-buttons').hide();
-        }
-    } else if (recursionDepth) {
-        $('#set-g-random-simple').hide();
-        if (!examples) {
-            $('#set-g-from-preset').hide();
-        }
-    }
+  }
 }
 
 /**
@@ -154,26 +154,26 @@ function parseUrlParameters() {
 * E:N|E '+' E|E '*' E|'-' E|'(' E ')'; N:'0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9';
 */
 function decodeGrammar(productionString) {
-    var duo, nonterminal, replacementString;
-    var replacements = [];
-    var productions = {};
-    var blocks = productionString.split(";");
-    initialNonterminal_ = blocks[0].split(':')[0].trim();
-    for (let blockIndex=0; blockIndex < blocks.length; blockIndex++) {
-        if (blocks[blockIndex].trim() == '') {
-            continue;
-        }
-        duo = blocks[blockIndex].split(':');
-        if (duo.length != 2) {
-            console.error("Invalid syntax for given grammar productions: " + blocks[blockIndex]);
-            continue;
-        }
-        nonterminal = duo[0].trim();
-        replacementString = duo[1];
-        replacements = (interpretReplacementStrings(replacementString.split('|')));
-        productions[nonterminal] = replacements;
+  var duo, nonterminal, replacementString;
+  var replacements = [];
+  var productions = {};
+  var blocks = productionString.split(";");
+  initialNonterminal_ = blocks[0].split(':')[0].trim();
+  for (let blockIndex=0; blockIndex < blocks.length; blockIndex++) {
+    if (blocks[blockIndex].trim() == '') {
+      continue;
     }
-    return productions;
+    duo = blocks[blockIndex].split(':');
+    if (duo.length != 2) {
+      console.error("Invalid syntax for given grammar productions: " + blocks[blockIndex]);
+      continue;
+    }
+    nonterminal = duo[0].trim();
+    replacementString = duo[1];
+    replacements = (interpretReplacementStrings(replacementString.split('|')));
+    productions[nonterminal] = replacements;
+  }
+  return productions;
 }
 
 /**
@@ -182,28 +182,28 @@ function decodeGrammar(productionString) {
 * a list of lists
 */
 function interpretReplacementStrings(replacementStrings) {
-    const isNumber = (value) => typeof(value) == 'number';
-    var replacements = [];
-    var replacementUnits;
-    for (let i=0; i<replacementStrings.length; i++) {
-        replacementUnits = replacementStrings[i].trim().split(' ');
-        let firstUnit = replacementUnits[0];
-        if (replacementUnits.length == 1 && firstUnit.match(/^\'\d+\'$/g)) {
-            // A full list of integer terminals is interpreted differently
-            replacements.push(parseInt(firstUnit.replace(/^\'+|\'+$/g, '')));
-        } else {
-            replacements.push(replacementUnits);
-        }
+  const isNumber = (value) => typeof(value) == 'number';
+  var replacements = [];
+  var replacementUnits;
+  for (let i=0; i<replacementStrings.length; i++) {
+    replacementUnits = replacementStrings[i].trim().split(' ');
+    let firstUnit = replacementUnits[0];
+    if (replacementUnits.length == 1 && firstUnit.match(/^\'\d+\'$/g)) {
+      // A full list of integer terminals is interpreted differently
+      replacements.push(parseInt(firstUnit.replace(/^\'+|\'+$/g, '')));
+    } else {
+      replacements.push(replacementUnits);
     }
-    if (!replacements.every(isNumber)) {
-        // If not all of them are integers then we have to resort to the long form standard
-        for (let i=0; i<replacements.length; i++) {
-            if (isNumber(replacements[i])) {
-                replacements[i] = [`'${replacements[i].toString()}'`];
-            }
-        }
+  }
+  if (!replacements.every(isNumber)) {
+    // If not all of them are integers then we have to resort to the long form standard
+    for (let i=0; i<replacements.length; i++) {
+      if (isNumber(replacements[i])) {
+        replacements[i] = [`'${replacements[i].toString()}'`];
+      }
     }
-    return replacements
+  }
+  return replacements
 }
 
 /******************************************************************************/
@@ -214,18 +214,18 @@ function interpretReplacementStrings(replacementStrings) {
 * Fills the user-facing table with the given grammar productions.
 */
 function fillProductionsWindow(productions) {
-    var keys = Object.keys(productions)
-    var describedProductions = [];
-    for (let i=0; i<keys.length; i++) {
-        describedProductions = describedProductions.concat(describeAndReduceProductions(keys[i], productions[keys[i]]));
-    }
+  var keys = Object.keys(productions)
+  var describedProductions = [];
+  for (let i=0; i<keys.length; i++) {
+    describedProductions = describedProductions.concat(describeAndReduceProductions(keys[i], productions[keys[i]]));
+  }
 
-    var list = document.getElementById('production-list');
-    for (let j = 0; j < describedProductions.length; j++) {
-        var div = document.createElement('div');
-        div.innerHTML = describedProductions[j];
-        list.appendChild(div);
-    }
+  var list = document.getElementById('production-list');
+  for (let j = 0; j < describedProductions.length; j++) {
+    var div = document.createElement('div');
+    div.innerHTML = describedProductions[j];
+    list.appendChild(div);
+  }
 }
 
 /**
@@ -234,31 +234,31 @@ function fillProductionsWindow(productions) {
 * If replacements is an incremental list of integers they are reduced appropriately
 */
 function describeAndReduceProductions(nonterminal, replacements) {
-    var isCompressable = true;
-    if (typeof(replacements[0]) == 'number' && replacements.length > 1) {
-        for (let i=1; i<replacements.length; i++) {
-            if (replacements[i] != replacements[i-1] + 1) {
-                isCompressable = false;
-                break;
-            }
-        }
-    } else {
+  var isCompressable = true;
+  if (typeof(replacements[0]) == 'number' && replacements.length > 1) {
+    for (let i=1; i<replacements.length; i++) {
+      if (replacements[i] != replacements[i-1] + 1) {
         isCompressable = false;
+        break;
+      }
     }
+  } else {
+    isCompressable = false;
+  }
 
-    if (isCompressable) {
-        if (replacements.length == 2) {
-            // Use syntax A|B where B = A+1, meaning 'Number A or number B'
-            return [`<span class="nonterminal">${nonterminal}</span> ${ARROW} ${replacements[0]}|${replacements[1]}`]
-        }
-        // Use syntax A-B, meaning 'Any number from A through B'
-        return [`<span class="nonterminal">${nonterminal}</span> ${ARROW} ${replacements[0]}-${replacements[replacements.length - 1]}`]
+  if (isCompressable) {
+    if (replacements.length == 2) {
+      // Use syntax A|B where B = A+1, meaning 'Number A or number B'
+      return [`<span class="nonterminal">${nonterminal}</span> ${ARROW} ${replacements[0]}|${replacements[1]}`]
     }
-    var returnList = [];
-    for (let i=0; i<replacements.length; i++) {
-        returnList.push(describeProduction(nonterminal, replacements[i]));
-    }
-    return returnList;
+    // Use syntax A-B, meaning 'Any number from A through B'
+    return [`<span class="nonterminal">${nonterminal}</span> ${ARROW} ${replacements[0]}-${replacements[replacements.length - 1]}`]
+  }
+  var returnList = [];
+  for (let i=0; i<replacements.length; i++) {
+    returnList.push(describeProduction(nonterminal, replacements[i]));
+  }
+  return returnList;
 }
 
 /******************************************************************************/
@@ -269,39 +269,39 @@ function describeAndReduceProductions(nonterminal, replacements) {
 * Sets the equation generator to be of the given type
 */
 function setGenerator(type) {
-    var $button = $('#set-g-' + type);
-    var buttonLabel = $button.html();
-    var buttonType = $button.attr('g-type');
-    $('#generate-button').html(buttonLabel);
-    $('#generate-button').attr('g-type', buttonType);
+  var $button = $('#set-g-' + type);
+  var buttonLabel = $button.html();
+  var buttonType = $button.attr('g-type');
+  $('#generate-button').html(buttonLabel);
+  $('#generate-button').attr('g-type', buttonType);
 }
 
 /**
 * Returns a (string) new equation for the user to try to build depending on the selected generator.
 */
 function generateTarget($button) {
-    if ($button.getAttribute('g-type') == 'random') {
-        return randomExpression(initialNonterminal_, productions_, recursionDepth_);
-    } else if ($button.getAttribute('g-type') == 'random-simple') {
-        return randomExpression(initialNonterminal_, productions_, RECURSIONDEPTH_SIMPLE);
-    } else {
-        nextExample_ = (nextExample_ + 1) % examples_.length;
-        return examples_[nextExample_];
-    }
+  if ($button.getAttribute('g-type') == 'random') {
+    return randomExpression(initialNonterminal_, productions_, recursionDepth_);
+  } else if ($button.getAttribute('g-type') == 'random-simple') {
+    return randomExpression(initialNonterminal_, productions_, RECURSIONDEPTH_SIMPLE);
+  } else {
+    nextExample_ = (nextExample_ + 1) % examples_.length;
+    return examples_[nextExample_];
+  }
 }
 
 /**
 * Each time a new non-terminal is created it needs to be bound to the click event.
 */
 function reapplyNonterminalClickEvent() {
-    $('#cfg-equation .nonterminal').unbind('click');
-    //https://stackoverflow.com/a/44753671
-    $('#cfg-equation .nonterminal').on('click', function(event) {
-        setActiveNonterminal($(event.target));
-        $('#selection-popup').css({left: event.pageX});
-        $('#selection-popup').css({top: event.pageY});
-        $('#selection-popup').show();
-    });
+  $('#cfg-equation .nonterminal').unbind('click');
+  //https://stackoverflow.com/a/44753671
+  $('#cfg-equation .nonterminal').on('click', function(event) {
+    setActiveNonterminal($(event.target));
+    $('#selection-popup').css({left: event.pageX});
+    $('#selection-popup').css({top: event.pageY});
+    $('#selection-popup').show();
+  });
 }
 
 /**
@@ -310,15 +310,15 @@ function reapplyNonterminalClickEvent() {
 * If they match, applies an effect, else removes it.
 */
 function testMatchingEquations() {
-    if ($('#cfg-target').val().trim() == $('#cfg-equation').html().trim()) {
-        $('#cfg-equation').addClass('success');
-        $('#generate-button').addClass('success');
-        $('#generate-dropdown').addClass('success');
-    } else {
-        $('#cfg-equation').removeClass('success');
-        $('#generate-button').removeClass('success');
-        $('#generate-dropdown').removeClass('success');
-    }
+  if ($('#cfg-target').val().trim() == $('#cfg-equation').html().trim()) {
+    $('#cfg-equation').addClass('success');
+    $('#generate-button').addClass('success');
+    $('#generate-dropdown').addClass('success');
+  } else {
+    $('#cfg-equation').removeClass('success');
+    $('#generate-button').removeClass('success');
+    $('#generate-dropdown').removeClass('success');
+  }
 }
 
 /**
@@ -326,52 +326,52 @@ function testMatchingEquations() {
 * Prepares the popup appropriately.
 */
 function setActiveNonterminal($target) {
-    $activeNonterminal_ = $target;
-    var nonterminal = $target.html();
-    $('#selection-popup').html('');
-    if (Object.keys(productions_).indexOf(nonterminal) < 0) {
-        console.error(`Could not find non-terminal ${nonterminal} in available productions.`);
-        $('#selection-popup').html(gettext('No productions available.'));
-        return;
-    }
-    $('#selection-popup').html(getPopupVal(nonterminal, productions_[nonterminal]));
-    $('.cfg-popup-replacement').on('click', function(event) {
-        applyProduction($(event.target));
-        $('#selection-popup').hide();
-        testMatchingEquations();
-    });
+  $activeNonterminal_ = $target;
+  var nonterminal = $target.html();
+  $('#selection-popup').html('');
+  if (Object.keys(productions_).indexOf(nonterminal) < 0) {
+    console.error(`Could not find non-terminal ${nonterminal} in available productions.`);
+    $('#selection-popup').html(gettext('No productions available.'));
+    return;
+  }
+  $('#selection-popup').html(getPopupVal(nonterminal, productions_[nonterminal]));
+  $('.cfg-popup-replacement').on('click', function(event) {
+    applyProduction($(event.target));
+    $('#selection-popup').hide();
+    testMatchingEquations();
+  });
 }
 
 /**
 * Replaces the active non-terminal using the target production.
 */
 function applyProduction($target) {
-    var nonterminal = $activeNonterminal_.html();
-    var replacementIndex = parseInt($target.attr('cfg-replacement'));
-    var replacement = productions_[nonterminal][replacementIndex];
-    $('#undo-button').prop('disabled', false);
-    $activeNonterminal_.replaceWith(describeProductionReplacement(replacement));
-    reapplyNonterminalClickEvent();
-    $activeNonterminal_ = null;
-    // Track history
-    let cfg_equation = $('#cfg-equation').html();
-    addHistoryElement(cfg_equation, describeProduction(nonterminal, replacement));
+  var nonterminal = $activeNonterminal_.html();
+  var replacementIndex = parseInt($target.attr('cfg-replacement'));
+  var replacement = productions_[nonterminal][replacementIndex];
+  $('#undo-button').prop('disabled', false);
+  $activeNonterminal_.replaceWith(describeProductionReplacement(replacement));
+  reapplyNonterminalClickEvent();
+  $activeNonterminal_ = null;
+  // Track history
+  let cfg_equation = $('#cfg-equation').html();
+  addHistoryElement(cfg_equation, describeProduction(nonterminal, replacement));
 }
 
 /**
 * Replaces the existing equation with the one immediately before.
 */
 function undo() {
-    historyStack_.pop();
-    let cfg_equation = historyStack_[historyStack_.length -1 ];
-    $('#cfg-equation').html(cfg_equation);
-    $activeNonterminal_ = null;
-    if (historyStack_.length <= 1) {
-        $('#undo-button').prop('disabled', true);
-    }
-    historyListElem_.removeChild(historyListElem_.lastChild);
-    reapplyNonterminalClickEvent();
-    testMatchingEquations();
+  historyStack_.pop();
+  let cfg_equation = historyStack_[historyStack_.length -1 ];
+  $('#cfg-equation').html(cfg_equation);
+  $activeNonterminal_ = null;
+  if (historyStack_.length <= 1) {
+    $('#undo-button').prop('disabled', true);
+  }
+  historyListElem_.removeChild(historyListElem_.lastChild);
+  reapplyNonterminalClickEvent();
+  testMatchingEquations();
 }
 
 /**
@@ -380,25 +380,25 @@ function undo() {
  * @param {production}: Production that resulted in the equation.
  */
 function addHistoryElement(cfg_equation, production=null) {
-    historyStack_.push(cfg_equation);
-    var outer_div = document.createElement('div');
-    outer_div.classList.add('history-item');
+  historyStack_.push(cfg_equation);
+  var outer_div = document.createElement('div');
+  outer_div.classList.add('history-item');
 
-    // Create div for production
-    if (production) {
-        var production_div = document.createElement('div');
-        production_div.classList.add('history-production');
-        production_div.innerHTML = production;
-        outer_div.appendChild(production_div);
-    }
+  // Create div for production
+  if (production) {
+    var production_div = document.createElement('div');
+    production_div.classList.add('history-production');
+    production_div.innerHTML = production;
+    outer_div.appendChild(production_div);
+  }
 
-    // Create div for equation
-    var equation_div = document.createElement('div');
-    equation_div.classList.add('history-equation');
-    equation_div.innerHTML = cfg_equation;
-    outer_div.appendChild(equation_div);
+  // Create div for equation
+  var equation_div = document.createElement('div');
+  equation_div.classList.add('history-equation');
+  equation_div.innerHTML = cfg_equation;
+  outer_div.appendChild(equation_div);
 
-    historyListElem_.appendChild(outer_div);
+  historyListElem_.appendChild(outer_div);
 }
 
 /**
@@ -406,14 +406,14 @@ function addHistoryElement(cfg_equation, production=null) {
 * a replacement for the given non-terminal.
 */
 function getPopupVal(nonterminal, replacements) {
-    var code = '<div class="btn-group-vertical">';
-    var nextStr = "";
-    for (let i=0; i<replacements.length; i++) {
-        nextStr = describeProduction(nonterminal, replacements[i]);
-        code += `<button type="button" class="btn btn-secondary cfg-popup-replacement" cfg-replacement="${i}">${nextStr}</button>`;
-    }
-    code += '</div>';
-    return code;
+  var code = '<div class="btn-group-vertical">';
+  var nextStr = "";
+  for (let i=0; i<replacements.length; i++) {
+    nextStr = describeProduction(nonterminal, replacements[i]);
+    code += `<button type="button" class="btn btn-secondary cfg-popup-replacement" cfg-replacement="${i}">${nextStr}</button>`;
+  }
+  code += '</div>';
+  return code;
 }
 
 /**
@@ -422,19 +422,19 @@ function getPopupVal(nonterminal, replacements) {
 * e.g. E -> E+E
 */
 function describeProduction(nonterminal, replacement) {
-    var returnText = `<span class="nonterminal">${nonterminal}</span> ${ARROW} `;
-    if (typeof(replacement) != 'object') {
-        return returnText + replacement.toString().replace(/^\'+|\'+$/g, '');
+  var returnText = `<span class="nonterminal">${nonterminal}</span> ${ARROW} `;
+  if (typeof(replacement) != 'object') {
+    return returnText + replacement.toString().replace(/^\'+|\'+$/g, '');
+  }
+  for (let i=0; i<replacement.length; i++) {
+    let replacement_item = replacement[i];
+    if (replacement_item.startsWith('\'') && replacement_item.endsWith('\'')) {
+      returnText += replacement_item.substring(1, replacement_item.length - 1);
+    } else {
+      returnText += `<span class="nonterminal">${replacement_item}</span >`;
     }
-    for (let i=0; i<replacement.length; i++) {
-        let replacement_item = replacement[i];
-        if (replacement_item.startsWith('\'') && replacement_item.endsWith('\'')) {
-            returnText += replacement_item.substring(1, replacement_item.length - 1);
-        } else {
-            returnText += `<span class="nonterminal">${replacement_item}</span >`;
-        }
-    }
-    return returnText;
+  }
+  return returnText;
 }
 
 /**
@@ -444,18 +444,18 @@ function describeProduction(nonterminal, replacement) {
 * e.g. <span class="nonterminal">E</span>+<span class="nonterminal">E</span>
 */
 function describeProductionReplacement(replacement) {
-    if (typeof(replacement) != 'object') {
-        return replacement.toString().replace(/^\'+|\'+$/g, '');
+  if (typeof(replacement) != 'object') {
+    return replacement.toString().replace(/^\'+|\'+$/g, '');
+  }
+  var code = "";
+  for (let i=0; i<replacement.length; i++) {
+    if (isTerminal(replacement[i])) {
+      code += replacement[i].toString().replace(/^\'+|\'+$/g, '');
+    } else {
+      code += `<span class="nonterminal">${replacement[i].toString().replace(/^\'+|\'+$/g, '')}</span>`;
     }
-    var code = "";
-    for (let i=0; i<replacement.length; i++) {
-        if (isTerminal(replacement[i])) {
-            code += replacement[i].toString().replace(/^\'+|\'+$/g, '');
-        } else {
-            code += `<span class="nonterminal">${replacement[i].toString().replace(/^\'+|\'+$/g, '')}</span>`;
-        }
-    }
-    return code;
+  }
+  return code;
 }
 
 /******************************************************************************/
@@ -467,7 +467,7 @@ function describeProductionReplacement(replacement) {
 * From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
 */
 function getRandomInt(max) {
-    return Math.floor(Math.random() * Math.floor(max));
+  return Math.floor(Math.random() * Math.floor(max));
 }
 
 /**
@@ -478,13 +478,13 @@ function getRandomInt(max) {
 * inverted comma ('), with at least 1 character in between
 */
 function isTerminal(s) {
-    return (typeof(s) == 'number' ||
-    (
-        s.length > 2
-        && s.charAt(0) == "'"
-        && s.charAt(s.length - 1) == "'"
-        ));
-    }
+  return (typeof(s) == 'number' ||
+  (
+    s.length > 2
+    && s.charAt(0) == "'"
+    && s.charAt(s.length - 1) == "'"
+    ));
+  }
 
 /**
 * Returns a random expression generated from the given grammar productions.
@@ -497,29 +497,29 @@ function isTerminal(s) {
 * @param {Number} maxDepth maximum depth of recursion
 */
 function randomExpression(startChar, productions, maxDepth) {
-    const attempts = 100;
-    var attempt = 0;
-    var success = false;
-    var result;
-    while (attempt < attempts && !success) {
-        try {
-            result = recursiveRandomExpression(startChar, productions, maxDepth);
-            success = true;
-        } catch (error) {
-            // If the error is not the error we're trying to catch then re-throw it
-            if (!error.startsWith("Max depth")) {
-                throw error;
-            }
-        }
-        attempt++;
+  const attempts = 100;
+  var attempt = 0;
+  var success = false;
+  var result;
+  while (attempt < attempts && !success) {
+    try {
+      result = recursiveRandomExpression(startChar, productions, maxDepth);
+      success = true;
+    } catch (error) {
+      // If the error is not the error we're trying to catch then re-throw it
+      if (!error.startsWith("Max depth")) {
+        throw error;
+      }
     }
-    if (!success) {
-        $('#error-notice').html(gettext("The generator failed to finish a new equation too many times.") + "<br>" +
-        gettext("This could just be unlucky (try again!), or it could indicate a problem with your productions."));
-        $('#error-notice').show();
-        return "";
-    }
-    return result;
+    attempt++;
+  }
+  if (!success) {
+    $('#error-notice').html(gettext("The generator failed to finish a new equation too many times.") + "<br>" +
+    gettext("This could just be unlucky (try again!), or it could indicate a problem with your productions."));
+    $('#error-notice').show();
+    return "";
+  }
+  return result;
 }
 
 /**
@@ -530,32 +530,32 @@ function randomExpression(startChar, productions, maxDepth) {
 * @param {Number} maxDepth maximum depth of recursion
 */
 function recursiveRandomExpression(replaced, productions, maxDepth) {
-    if (maxDepth <= 0) {
-        throw "Max depth reached replacing " + replaced;
-    }
+  if (maxDepth <= 0) {
+    throw "Max depth reached replacing " + replaced;
+  }
 
-    try {
-        var replacement = productions[replaced][getRandomInt(productions[replaced].length)]
-    } catch (error) {
-        console.error(error);
-        $('#error-notice').html(gettext("An error occurred while generating a new equation.") + "<br>" +
-        gettext("There could be a non-terminal in the grammar productions with no corresponding production."));
-        $('#error-notice').show();
-        return;
+  try {
+    var replacement = productions[replaced][getRandomInt(productions[replaced].length)]
+  } catch (error) {
+    console.error(error);
+    $('#error-notice').html(gettext("An error occurred while generating a new equation.") + "<br>" +
+    gettext("There could be a non-terminal in the grammar productions with no corresponding production."));
+    $('#error-notice').show();
+    return;
+  }
+  $('#error-notice').hide();
+  if (typeof(replacement) != 'object') {
+    return replacement.toString().replace(/^\'+|\'+$/g, '');
+  }
+  var returnString = '';
+  for (let i=0; i<replacement.length; i++) {
+    if (isTerminal(replacement[i])) {
+      returnString += replacement[i].toString().replace(/^\'+|\'+$/g, '');
+    } else {
+      returnString += recursiveRandomExpression(replacement[i], productions, maxDepth - 1);
     }
-    $('#error-notice').hide();
-    if (typeof(replacement) != 'object') {
-        return replacement.toString().replace(/^\'+|\'+$/g, '');
-    }
-    var returnString = '';
-    for (let i=0; i<replacement.length; i++) {
-        if (isTerminal(replacement[i])) {
-            returnString += replacement[i].toString().replace(/^\'+|\'+$/g, '');
-        } else {
-            returnString += recursiveRandomExpression(replacement[i], productions, maxDepth - 1);
-        }
-    }
-    return returnString;
+  }
+  return returnString;
 }
 
 /******************************************************************************/
@@ -566,54 +566,54 @@ function recursiveRandomExpression(replaced, productions, maxDepth) {
 * Sets the link to the base url of the interactive
 */
 function resetLink() {
-    var instruction = gettext("This link will open the default version of this interactive:");
-    var link = window.location.href.split('?', 1)[0].replace(/^\/+|\/+$/g, '');
-    $("#cfg-grammar-link").html(`${instruction}<br><a target="_blank" href=${link}>${link}</a>`);
+  var instruction = gettext("This link will open the default version of this interactive:");
+  var link = window.location.href.split('?', 1)[0].replace(/^\/+|\/+$/g, '');
+  $("#cfg-grammar-link").html(`${instruction}<br><a target="_blank" href=${link}>${link}</a>`);
 }
 
 /**
 * Sets the link based on the productions submitted
 */
 function getLink() {
-    var instruction = gettext("This link will open the interactive with your set productions:");
-    var productions = $("#cfg-grammar-input").val().trim();
-    if (productions.length <= 0) {
-        $("#cfg-grammar-link").html("");
-        return;
+  var instruction = gettext("This link will open the interactive with your set productions:");
+  var productions = $("#cfg-grammar-input").val().trim();
+  if (productions.length <= 0) {
+    $("#cfg-grammar-link").html("");
+    return;
+  }
+  var productionsParameter = percentEncode(productions.replace(/\n/g, ' '));
+  var otherParameters = "";
+  if ($("#generator-checkbox").prop('checked')){
+    // 5 chosen arbitrarily
+    otherParameters += "&recursion-depth=5&retry-if-fail=true";
+  } else {
+    otherParameters += "&hide-generator=true";
+  }
+  if ($("#examples-checkbox").prop('checked')){
+    var examples = $("#cfg-example-input").val().trim();
+    if (examples.length > 0) {
+      otherParameters += '&examples=' + percentEncode(examples.replace(/\n/g, '|'));
     }
-    var productionsParameter = percentEncode(productions.replace(/\n/g, ' '));
-    var otherParameters = "";
-    if ($("#generator-checkbox").prop('checked')){
-        // 5 chosen arbitrarily
-        otherParameters += "&recursion-depth=5&retry-if-fail=true";
-    } else {
-        otherParameters += "&hide-generator=true";
-    }
-    if ($("#examples-checkbox").prop('checked')){
-        var examples = $("#cfg-example-input").val().trim();
-        if (examples.length > 0) {
-            otherParameters += '&examples=' + percentEncode(examples.replace(/\n/g, '|'));
-        }
-    }
-    // When the user switches between generator types a # appears at the end of the url
-    // This needs to be removed for the new link, or not added in the first place:
-    var basePath = window.location.href.split('?', 1)[0].replace(/\#+$/g, '');
-    var fullUrl = basePath + "?productions=" + productionsParameter + otherParameters;
-    $("#cfg-grammar-link").html(`${instruction}<br><a target="_blank" href=${fullUrl}>${fullUrl}</a>`);
+  }
+  // When the user switches between generator types a # appears at the end of the url
+  // This needs to be removed for the new link, or not added in the first place:
+  var basePath = window.location.href.split('?', 1)[0].replace(/\#+$/g, '');
+  var fullUrl = basePath + "?productions=" + productionsParameter + otherParameters;
+  $("#cfg-grammar-link").html(`${instruction}<br><a target="_blank" href=${fullUrl}>${fullUrl}</a>`);
 }
 
 function toggleExamplesWindow() {
-    if ($("#examples-checkbox").prop('checked')){
-        $("#cfg-example-input-parent").removeClass('d-none');
-    } else {
-        $("#cfg-example-input-parent").addClass('d-none');
-        $("#cfg-example-input").val('')
-    }
+  if ($("#examples-checkbox").prop('checked')){
+    $("#cfg-example-input-parent").removeClass('d-none');
+  } else {
+    $("#cfg-example-input-parent").addClass('d-none');
+    $("#cfg-example-input").val('')
+  }
 }
 
 /**
 * Returns the given string percent-encoded
 */
 function percentEncode(string) {
-    return encodeURIComponent(string);
+  return encodeURIComponent(string);
 }

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
@@ -85,7 +85,7 @@ $(document).ready(function() {
     $('#cfg-target').val(randomExpression(recursionDepth_));
   }
   prefillGrammar();
-  getLink();
+  $("#cfg-grammar-link").html("");
 });
 
 /**
@@ -136,10 +136,11 @@ function parseUrlParameters() {
     $('#set-g-from-preset').hide();
   }
   if (recursionDepth) {
-    if (parseInt(recursionDepth) > RECURSIONDEPTH_MAX) {
-      $('#error-notice').html(gettext("The recursion depth in the URL is too high so we ignored it."));
+    recursionDepth = parseInt(recursionDepth);
+    if (recursionDepth > RECURSIONDEPTH_MAX) {
+      $('#error-notice').html(gettext("The recursion depth in the URL is too high so it was ignored."));
       $('#error-notice').show();
-    } else if (parseInt(recursionDepth) > 0) {
+    } else if (recursionDepth > 0) {
       recursionDepth_ = parseInt(recursionDepth);
       $('#error-notice').hide();
     }
@@ -577,7 +578,6 @@ function findPossibleExpressionsAtDepth(depth) {
       }
     }
   }
-  return
 }
 
 /**
@@ -656,7 +656,6 @@ function prefillGrammar() {
     }
     yacc += ';\n';
   }
-  console.log(yacc);
   $("#cfg-grammar-input").val(yacc);
 }
 
@@ -681,16 +680,16 @@ function getLink() {
   }
   var productionsParameter = percentEncode(productions.replace(/\n/g, ' '));
   var otherParameters = "";
-  if ($("#generator-checkbox").prop('checked')){
-    // 5 chosen arbitrarily
-    otherParameters += "";
-  } else {
-    otherParameters += "&hide-generator=true";
-  }
   if ($("#examples-checkbox").prop('checked')){
     var examples = $("#cfg-example-input").val().trim();
     if (examples.length > 0) {
       otherParameters += '&examples=' + percentEncode(examples.replace(/\n/g, '|'));
+    }
+  }
+  if (!$("#generator-checkbox").prop('checked')){
+    otherParameters += '&hide-generator=true';
+    if (!$("#examples-checkbox").prop('checked')) {
+      otherParameters += '&editable-target=true';
     }
   }
   // When the user switches between generator types a # appears at the end of the url
@@ -700,6 +699,10 @@ function getLink() {
   $("#cfg-grammar-link").html(`${instruction}<br><a target="_blank" href=${fullUrl}>${fullUrl}</a>`);
 }
 
+/**
+* Changes the visibility of the example input window depending on whether or not
+* the appropriate checkbox is checked
+*/
 function toggleExamplesWindow() {
   if ($("#examples-checkbox").prop('checked')){
     $("#cfg-example-input-parent").removeClass('d-none');

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
@@ -588,7 +588,7 @@ function randomExpression(depth) {
     parseAllExpressions();
   }
   try {
-    return recursiveRandomExpression(depth, initialNonterminal_);
+    return recursiveRandomExpression(depth, initialNonterminal_).replace(/\'+/g, '');
   } catch (error) {
     // If the error is not the one we expect to catch then rethrow it
     if (!error.startsWith(depth.toString())) {
@@ -610,6 +610,7 @@ function randomExpression(depth) {
 
 /**
 * Recursive step for generating random expressions
+* Returns a string of two inverted commas with only terminals in between
 */
 function recursiveRandomExpression(depth, nonterminal) {
   if (expressionsAtDepth_[depth][nonterminal].length <= 0) {
@@ -633,7 +634,7 @@ function recursiveRandomExpression(depth, nonterminal) {
       expression += recursiveRandomExpression(newPath[0], newPath[1]);
     }
   }
-  return expression.replace(/\'+/g, '');
+  return expression;
 }
 
 /******************************************************************************/

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/js/cfg-parsing-challenge.js
@@ -17,8 +17,8 @@ const DEFAULT_PRODUCTIONS = {
   "N": [0,1,2,3,4,5,6,7,8,9]
 };
 
-const RECURSIONDEPTH_SIMPLE = 2;
-const RECURSIONDEPTH_DEFAULT = 4;
+const RECURSIONDEPTH_SIMPLE = 3;
+const RECURSIONDEPTH_DEFAULT = 5;
 const ARROW = '&#10142;'
 
 var $activeNonterminal_ = null;
@@ -109,6 +109,11 @@ function resetEquation() {
 function parseUrlParameters() {
   if (urlParameters.getUrlParameter('hide-builder') == 'true') {
     $('#grammar-builder-button').hide();
+  }
+  if (urlParameters.getUrlParameter('editable-target') == 'true') {
+    $('#cfg-target').attr('disabled', false);
+  } else {
+    $('#cfg-target').attr('disabled', true);
   }
   var grammar = urlParameters.getUrlParameter('productions');
   var examples = urlParameters.getUrlParameter('examples');

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/scss/cfg-parsing-challenge.scss
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/scss/cfg-parsing-challenge.scss
@@ -17,7 +17,9 @@ $non-terminal: #6c757d;
 }
 
 #cfg-equation {
-    font-size: 4rem;
+  font-size: 4rem;
+  overflow-x: auto;
+  white-space: nowrap;
   .nonterminal:hover {
     color: darken($non-terminal, 10%);
     cursor: pointer;
@@ -61,7 +63,7 @@ $non-terminal: #6c757d;
 #selection-popup {
   display: none;
   position: absolute;
-  background-color: #ececec;
+  background-color: #6c757d; // bootstrap secondary
   color: white;
   .btn {
     text-align: start;

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/scss/cfg-parsing-challenge.scss
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/scss/cfg-parsing-challenge.scss
@@ -76,7 +76,6 @@ $non-terminal: #6c757d;
 
 #error-notice {
   display: none;
-  color: red;
   font-family: sans-serif;
   text-align: center;
 }

--- a/csfieldguide/static/interactives/cfg-parsing-challenge/scss/cfg-parsing-challenge.scss
+++ b/csfieldguide/static/interactives/cfg-parsing-challenge/scss/cfg-parsing-challenge.scss
@@ -12,8 +12,8 @@ $non-terminal: #6c757d;
 
 // Scoped outside due to usage on many components
 .nonterminal {
-    font-weight: bold;
-    color: $non-terminal;
+  font-weight: bold;
+  color: $non-terminal;
 }
 
 #cfg-equation {
@@ -43,19 +43,19 @@ $non-terminal: #6c757d;
 }
 
 #production-list {
-    font-size: 1.2rem;
+  font-size: 1.2rem;
 }
 
 #history-list {
-    min-height: 10rem;
-    font-size: 1.2rem;
-    .history-item:not(:last-child) {
-        border-bottom: 1px solid grey;
-    }
-    .history-production {
-        font-size: .8rem;
-        opacity: .9;
-    }
+  min-height: 10rem;
+  font-size: 1.2rem;
+  .history-item:not(:last-child) {
+    border-bottom: 1px solid grey;
+  }
+  .history-production {
+    font-size: .8rem;
+    opacity: .9;
+  }
 }
 
 #selection-popup {
@@ -67,10 +67,10 @@ $non-terminal: #6c757d;
     text-align: start;
   }
   .nonterminal {
-      color: #ccc;
-      // This prevents clicking on span with no data attribute,
-      // and allows user to click parent element correctly.
-      pointer-events: none;
+    color: #ccc;
+    // This prevents clicking on span with no data attribute,
+    // and allows user to click parent element correctly.
+    pointer-events: none;
   }
 }
 
@@ -93,5 +93,5 @@ $non-terminal: #6c757d;
 }
 
 button:disabled {
-    cursor: not-allowed;
+  cursor: not-allowed;
 }

--- a/csfieldguide/templates/interactives/cfg-parsing-challenge.html
+++ b/csfieldguide/templates/interactives/cfg-parsing-challenge.html
@@ -84,7 +84,7 @@
       </div>
       <div class="row justify-content-center mt-3">
         <div class="col-12" id="txt-try">
-          {% trans "Try to form:" %}
+          {% trans "Try to generate:" %}
         </div>
         <input type="text" class="col-6 text-center m-2 form-control" id="cfg-target" >
         <div class="btn-group" id="generator-buttons">
@@ -99,7 +99,7 @@
           </div>
         </div>
       </div>
-      <div class="row" id="error-notice"></div>
+      <div class="row alert-danger" id="error-notice"></div>
       <div class="d-flex justify-content-center my-2" id="cfg-equation"></div>
       <div class="d-flex justify-content-center mb-2">
         <button type="button" class="btn btn-secondary btn-sm m-1 float-right" id="undo-button">{% trans "Undo" %}</button>

--- a/csfieldguide/templates/interactives/cfg-parsing-challenge.html
+++ b/csfieldguide/templates/interactives/cfg-parsing-challenge.html
@@ -100,7 +100,9 @@
         </div>
       </div>
       <div class="row alert-danger" id="error-notice"></div>
-      <div class="d-flex justify-content-center my-2" id="cfg-equation"></div>
+      <div class="d-flex justify-content-center my-2">
+        <div id="cfg-equation"></div>
+      </div>
       <div class="d-flex justify-content-center mb-2">
         <button type="button" class="btn btn-secondary btn-sm m-1 float-right" id="undo-button">{% trans "Undo" %}</button>
         <button type="button" class="btn btn-danger btn-sm m-1 float-right" id="reset-button">{% trans "Reset" %}</button>

--- a/csfieldguide/templates/interactives/cfg-parsing-challenge.html
+++ b/csfieldguide/templates/interactives/cfg-parsing-challenge.html
@@ -107,22 +107,24 @@
       </div>
     </div>
     <div class="col-12 col-md-3">
-      <div class="py-2">
-        <div class="my-2 mx-auto list-container">
+      <div class="pt-2">
+        <div class="mx-auto list-container">
           <h3 class="h5">{% trans "Productions:" %}</h3>
           <div id="production-list"></div>
         </div>
       </div>
-      <div class="row" id="grammar-builder-button">
-        <button type="button" class="btn btn-primary mx-auto" data-toggle="modal" data-target="#grammar-builder">
-          {% trans "New productions" %}
-        </button>
-      </div>
-      <div class="py-2">
-        <div class="my-2 mx-auto list-container">
+      <div class="pt-2">
+        <div class="mx-auto list-container">
           <h3 class="h5">{% trans "History:" %}</h3>
           <div id="history-list"></div>
         </div>
+      </div>
+    </div>
+    <div class="col-12 py-2">
+      <div class="text-right"  id="grammar-builder-button">
+        <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle="modal" data-target="#grammar-builder">
+          {% trans "Customise productions" %}
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Resolves #1420 

- [x] Lower interface priority of 'New productions' button, hide it towards the bottom of the interactive as a additional feature.
    - Now the button is labelled `Customise Productions`
    - Now in bottom right and coloured grey (**Note:** Can still be removed entirely with parameter `hide-builder`)
- [x] Disable the text field that allows customising the equation text, as it's prone to errors.
    - Can be re-enabled with URL parameter `editable-target`
- [x] Increase average difficulty of random equations.
    - They are still random (I didn't force a minimum number of productions) but the difficulty skew is now more closely proportional to the probability of following each production.
- [x] Use wording 'generate' instead of 'form'
- [x] Fix wrapping behaviour of user expression
- [x] Remove internal shortcut for storing terminals as a list of elements as it no longer makes sense
- [x] Prefill production builder with appropriate YACC syntax for the existing productions
- [x] Use an en-dash in spaces rather than a hyphen to make the increasing-integers-production shortcut clearer when viewing negative numbers (e.g. -9--1 becomes -9 &#8211; -1)
- [x] Update README

![image](https://user-images.githubusercontent.com/25916475/136108996-3003c1f2-197b-401a-b5bf-5d65c8bc8d90.png)
