### PR TITLE
Fix solution to 'Representation for water' 

### DIFF
--- a/csfieldguide/chapters/content/en/data-representation/sections/text.md
+++ b/csfieldguide/chapters/content/en/data-representation/sections/text.md
@@ -415,8 +415,8 @@ Check the below panel once you think you have it.
 ```text
 w: 10111
 a: 00001
-t: 10111
-e: 10100
+t: 10100
+e: 00101
 r: 10010
 ```
 

--- a/csfieldguide/templates/appendices/contributors.html
+++ b/csfieldguide/templates/appendices/contributors.html
@@ -151,6 +151,7 @@
     <li><a href="https://github.com/mkong001">mkong001</a> (Minji Kong)</li>
     <li><a href="https://github.com/koreymitchell">koreymitchell</a> (Korey Mitchell)</li>
     <li><a href="https://github.com/wolginm">wolginm</a> (Mark Wolgin)</li>
+    <li><a href="https://github.com/michaelmcleodnz">michaelmcleodnz</a> (Michael McLeod)</li>
   </ul>
 
   <p>{% trans '<strong>Note:</strong> If there is an error in the list, please contact <a href="mailto:jack.morgan@canterbury.ac.nz">Jack Morgan</a>' %}</p>


### PR DESCRIPTION
## Proposed changes

Previous binary solution spelled 'wawtr'. Updated to spell 'water'.

### Checklist

- [x] I have read the contribution guidelines.
- [x] __(n/a)__ I have linked any relevant existing issues/suggestions in the description above (include `#???` in your description to reference an issue, where `???` is the issue number).
- [x] The pull request is requesting a merge into the `develop` branch.
- [x] __(n/a)__ I have added necessary documentation (if appropriate).
- [x] __(n/a)__ If I've added/modified/deleted a third-party system, I've updated the relevant license files.
- [x] I have added myself to the 'Community Contributors' section of `csfieldguide/templates/appendices/contributors.html`

