### PR TITLE
Release 3.12.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ and can also be built from the documentation source within the `docs/` directory
 ## Contributing
 
 We would love your help to make this guide the best it can be!
-Please read our
-[contribution guide](http://cs-field-guide.readthedocs.io/en/latest/getting_started/contributing_guide.html)
-to get started.
+Please read the [documentation](http://cs-field-guide.readthedocs.io/en/latest/) to get started.
 
 ## License
 

--- a/csfieldguide/config/__init__.py
+++ b/csfieldguide/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "3.12.4"
+__version__ = "3.12.5"

--- a/csfieldguide/static/interactives/rgb-mixer/scss/rgb-mixer.scss
+++ b/csfieldguide/static/interactives/rgb-mixer/scss/rgb-mixer.scss
@@ -1,4 +1,4 @@
-@import "node_modules/nouislider/distribute/nouislider.css";
+@import "static/interactives/rgb-mixer/node_modules/nouislider/distribute/nouislider";
 @import "node_modules/bootstrap/scss/functions";
 @import "node_modules/bootstrap/scss/variables";
 @import "node_modules/bootstrap/scss/mixins";

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,18 @@ All notable changes to this project will be documented in this file.
 We have listed major changes for each release below.
 `All downloads are available on GitHub <https://github.com/uccser/cs-field-guide/releases/>`__
 
+3.12.5
+==============================================================================
+
+**Release date:** 31st October 2022
+
+**Changelog:**
+
+- Fix bug where rgb-mixer interactive couldn't load required CSS file.
+- Dependency updates:
+
+    - Update cssnano from 5.1.13 to 5.1.14.
+
 3.12.4
 ==============================================================================
 


### PR DESCRIPTION
- Fix bug where rgb-mixer interactive couldn't load required CSS file.
- Dependency updates:

    - Update cssnano from 5.1.13 to 5.1.14.