### PR TITLE
Set UID of node user to the UID of the host user

### DIFF
--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Create Docker network
         run: docker network create uccser-development-stack
+      - name: Set DOCKER_UID variable
+        run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
       - name: Start systems
         run: docker compose -f docker-compose.local.yml up -d
       - name: Create static files

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Create Docker network
         run: docker network create uccser-development-stack
+        # Required for the node service
+      - name: Set DOCKER_UID variable
+        run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
       - name: Start systems
         run: docker compose -f docker-compose.local.yml up -d
       - name: Run Django system check
@@ -32,6 +35,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Create Docker network
         run: docker network create uccser-development-stack
+        # Required for the node service
       - name: Set DOCKER_UID variable
         run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
       - name: Start systems
@@ -127,6 +131,9 @@ jobs:
 
       - name: Create Docker network
         run: docker network create uccser-development-stack
+        # Required for the node service
+      - name: Set DOCKER_UID variable
+        run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
 
       - name: Start system
         run: docker compose -f docker-compose.local.yml up -d
@@ -175,6 +182,10 @@ jobs:
 
       - name: Create Docker network
         run: docker network create uccser-development-stack
+
+        # Required for the node service
+      - name: Set DOCKER_UID variable
+        run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
 
       - name: Start system
         run: docker compose -f docker-compose.local.yml up -d

--- a/csfieldguide/templates/appendices/contributors.html
+++ b/csfieldguide/templates/appendices/contributors.html
@@ -27,6 +27,7 @@
     <li>Hayley van Waas</li>
     <li>Courtney Bracefield</li>
     <li>Alasdair Smith</li>
+    <li>Philip Dolbel</li>
   </ul>
 
   <h2 id="interactive-development"><a href="#interactive-development">{% trans 'Interactive Development' %}</a></h2>

--- a/dev
+++ b/dev
@@ -15,6 +15,8 @@
 
 set -e
 
+export DOCKER_UID=$UID
+
 ERROR='\033[0;31m'
 SUCCESS='\033[0;32m'
 CODE='\033[0;36m'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -33,6 +33,8 @@ services:
         build:
             context: .
             dockerfile: ./infrastructure/local/node/Dockerfile
+            args:
+                DOCKER_UID: ${DOCKER_UID}
         image: cs_field_guide_local_node
         volumes:
             # https://burnedikt.com/dockerized-node-development-and-mounting-node-volumes/#exclude-node_modules-from-the-mount

--- a/infrastructure/local/node/Dockerfile
+++ b/infrastructure/local/node/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14.20.0-buster
 
-ARG DOCKER_UID
+ARG DOCKER_UID=1000
 RUN usermod -u $DOCKER_UID node
 
 # Install required system dependencies

--- a/infrastructure/local/node/Dockerfile
+++ b/infrastructure/local/node/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:14.20.0-buster
 
+ARG DOCKER_UID
+RUN usermod -u $DOCKER_UID node
+
 # Install required system dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \


### PR DESCRIPTION
## Proposed changes

On multi-user systems, such as the University of Canterbury linux systems, it appears that the node user created by the Nodejs docker base has a different UID to the host user. This is a problem because we use a bind mount, which retains the host users permissions, meaning that the node user doesn't have permission to access the mounted files.

This PR sets the UID of the node user to the value of the $UID bash shell variable to fix the permission issue.

### Checklist

*Change the space in the box to an `x` for those you have completed.
You can also fill these out after creating the pull request.
If you're unsure about any of them, don't hesitate to ask.
We're here to help!
This is simply a reminder of what we are going to look for before merging your change.*

- [x] I have read the contribution guidelines.
- [x] I have linked any relevant existing issues/suggestions in the description above (include `#???` in your description to reference an issue, where `???` is the issue number).
- [x] The pull request is requesting a merge into the `develop` branch.
- [x] I have added necessary documentation (if appropriate).
- [x] If I've added/modified/deleted a third-party system, I've updated the relevant license files.
- [x] I have added myself to the 'Community Contributors' section of `csfieldguide/templates/appendices/contributors.html`

