### PR TITLE
Add information about the list of panel types

### DIFF
--- a/docs/author/writing_guide.rst
+++ b/docs/author/writing_guide.rst
@@ -392,6 +392,7 @@ Supported panel types
 ---------------------
 
 These are the panel types that have built in styling for CSFG.
+Other panel types can be used, but they will not have any special styling.
 Have a play around with them to see how they look!
 
 

--- a/docs/author/writing_guide.rst
+++ b/docs/author/writing_guide.rst
@@ -405,7 +405,7 @@ Have a play around with them to see how they look!
 - spoiler
 - teacher-note
 
-  - NOTE: These will only be visible if Teacher Mode is enabled
+  - NOTE: Teacher Notes will only be visible if Teacher Mode is enabled
 
 ------------------------------------------------------------------------------
 

--- a/docs/author/writing_guide.rst
+++ b/docs/author/writing_guide.rst
@@ -388,6 +388,25 @@ Panel (Verto feature)
 
 `Click here to read the documentation on how to create a panel`_.
 
+Supported panel types
+---------------------
+
+These are the panel types that have built in styling for CSFG.
+Have a play around with them to see how they look!
+
+
+- additional-information
+- caution
+- curiosity
+- challenge
+- exercise
+- jargon-buster
+- project
+- spoiler
+- teacher-note
+
+  - NOTE: These will only be visible if Teacher Mode is enabled
+
 ------------------------------------------------------------------------------
 
 Scratch (Verto feature)


### PR DESCRIPTION
Add documentation about the different types of panels available with custom styles for authors in CSFG. Previously, the only way to know would be to look through the code, or look at other sections on the website as examples.