### PR TITLE
Revert "Bump pydocstyle from 6.2.3 to 6.3.0"

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,7 @@
 
 # Check Python style
 flake8==4.0.1
-pydocstyle==6.3.0
+pydocstyle==6.2.3
 
 #Coverage Tools
 coverage==6.5.0


### PR DESCRIPTION
Reverts uccser/cs-field-guide#2078