### PR TITLE
fix (currently-broken) link to tcpdump docs and reword sentence

### DIFF
--- a/csfieldguide/chapters/content/en/network-communication-protocols/sections/the-whole-story.md
+++ b/csfieldguide/chapters/content/en/network-communication-protocols/sections/the-whole-story.md
@@ -90,7 +90,7 @@ Think about the ratio of data to information (such as those in the header and fo
 
 # What does a packet trace look like?
 
-Here’s an example of a packet trace on our network [(using tcpdump on the mac)](http://support.apple.com/kb/HT3994)
+Here’s an example of a packet trace on our network [(using tcpdump on macOS)](https://developer.apple.com/documentation/network/recording_a_packet_trace)
 
 ```text
 00:55:18.540237 b8:e8:56:02:f8:3e > c4:a8:1d:17:a0:d3, ethertype IPv4 (0x0800), length 100: (tos 0x0, ttl 64, id 41564, offset 0, flags [none], proto UDP (17), length 86)

--- a/csfieldguide/templates/appendices/contributors.html
+++ b/csfieldguide/templates/appendices/contributors.html
@@ -153,6 +153,7 @@
     <li><a href="https://github.com/koreymitchell">koreymitchell</a> (Korey Mitchell)</li>
     <li><a href="https://github.com/wolginm">wolginm</a> (Mark Wolgin)</li>
     <li><a href="https://github.com/michaelmcleodnz">michaelmcleodnz</a> (Michael McLeod)</li>
+    <li><a href="https://github.com/CyberFlameGO">CyberFlameGO</a> (Aaron Lowe)</li>
   </ul>
 
   <p>{% trans '<strong>Note:</strong> If there is an error in the list, please contact <a href="mailto:jack.morgan@canterbury.ac.nz">Jack Morgan</a>' %}</p>


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request:

Reworded "the mac" to macOS for clarity, and replaced link to deleted Apple KB article with link to Apple tcpdump documentation, which seems to be the equivalent at present





### Checklist

*Change the space in the box to an `x` for those you have completed.
You can also fill these out after creating the pull request.
If you're unsure about any of them, don't hesitate to ask.
We're here to help!
This is simply a reminder of what we are going to look for before merging your change.*

- [x] I have read the contribution guidelines.
- [x] I have linked any relevant existing issues/suggestions in the description above (include `#???` in your description to reference an issue, where `???` is the issue number).
- [x] The pull request is requesting a merge into the `develop` branch.
- [x] I have added necessary documentation (if appropriate).
- [x] If I've added/modified/deleted a third-party system, I've updated the relevant license files.
- [x] I have added myself to the 'Community Contributors' section of `csfieldguide/templates/appendices/contributors.html`

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
Feel free to add any images that might be helpful to understand the initial problem/solution.
