### PR TITLE
Namespace radio buttons for CMY/RGB colour mixers

### DIFF
--- a/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
+++ b/csfieldguide/static/interactives/cmy-mixer/js/cmy-mixer.js
@@ -26,8 +26,8 @@ CMY_Mixer.result = document.getElementById('interactive-cmy-mixer-result');
 
 $(document).ready(function () {
   useHex = (urlParameters.getUrlParameter('hex') || 'false') == 'true';
-  $("input[id='hex-colour-code']").prop('checked', useHex);
-  $("input[id='dec-colour-code']").prop('checked', !useHex);
+  $("input[id='interactive-cmy-mixer-hex-colour-code']").prop('checked', useHex);
+  $("input[id='interactive-cmy-mixer-dec-colour-code']").prop('checked', !useHex);
 
   if ((urlParameters.getUrlParameter('hide-selector') || 'false') == 'true') {
     $("#numeral-system").addClass('d-none');
@@ -68,8 +68,8 @@ $(document).ready(function () {
 });
 
 
-$("input[name='colourCode']").click(function() {
-  var temp = $("input[name='colourCode']:checked").val() == 'hex';
+$("input[name='interactive-cmy-mixer-colourCode']").click(function() {
+  var temp = $("input[name='interactive-cmy-mixer-colourCode']:checked").val() == 'hex';
   if (temp != useHex) {
     useHex = temp;
     var c_val = $('#interactive-cmy-mixer-cyan-value').val() || 0;

--- a/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
+++ b/csfieldguide/static/interactives/rgb-mixer/js/rgb-mixer.js
@@ -34,8 +34,8 @@ $(document).ready(function () {
     $("#numeral-system").addClass('d-none');
     $("#pixelmania-logo").removeClass("d-none");
   }
-  $("input[id='hex-colour-code']").prop('checked', useHex);
-  $("input[id='dec-colour-code']").prop('checked', !useHex);
+  $("input[id='interactive-rgb-mixer-hex-colour-code']").prop('checked', useHex);
+  $("input[id='interactive-rgb-mixer-dec-colour-code']").prop('checked', !useHex);
 
   if ((urlParameters.getUrlParameter('hide-selector') || 'false') == 'true') {
     $("#numeral-system").addClass('d-none');
@@ -81,8 +81,8 @@ $(document).ready(function () {
 });
 
 
-$("input[name='colourCode']").click(function() {
-  var temp = $("input[name='colourCode']:checked").val() == 'hex';
+$("input[name='interactive-rgb-mixer-colourCode']").click(function() {
+  var temp = $("input[name='interactive-rgb-mixer-colourCode']:checked").val() == 'hex';
   if (temp != useHex) {
     useHex = temp;
     var r_val = $('#interactive-rgb-mixer-red-value').val() || 0;

--- a/csfieldguide/templates/interactives/cmy-mixer.html
+++ b/csfieldguide/templates/interactives/cmy-mixer.html
@@ -27,12 +27,12 @@
     </div>
     <div id="numeral-system" class="m-1">
       <div class="form-check form-check-inline">
-          <input class="form-check-input" type="radio" name="colourCode" value="dec" id="dec-colour-code" checked>
-          <label class="form-check-label" for="dec-colour-code">{% trans "Decimal" %}</label>
+          <input class="form-check-input" type="radio" name="interactive-cmy-mixer-colourCode" value="dec" id="interactive-cmy-mixer-dec-colour-code" checked>
+          <label class="form-check-label" for="interactive-cmy-mixer-dec-colour-code">{% trans "Decimal" %}</label>
       </div>
       <div class="form-check form-check-inline">
-          <input class="form-check-input" type="radio" name="colourCode" value="hex" id="hex-colour-code">
-          <label class="form-check-label" for="hex-colour-code">{% trans "Hexadecimal" %}</label>
+          <input class="form-check-input" type="radio" name="interactive-cmy-mixer-colourCode" value="hex" id="interactive-cmy-mixer-hex-colour-code">
+          <label class="form-check-label" for="interactive-cmy-mixer-hex-colour-code">{% trans "Hexadecimal" %}</label>
       </div>
     </div>
   </div>

--- a/csfieldguide/templates/interactives/rgb-mixer.html
+++ b/csfieldguide/templates/interactives/rgb-mixer.html
@@ -34,12 +34,12 @@
     </div>
     <div id="numeral-system" class="m-1">
       <div class="form-check form-check-inline">
-          <input class="form-check-input" type="radio" name="colourCode" value="dec" id="dec-colour-code" checked>
-          <label class="form-check-label" for="dec-colour-code">{% trans "Decimal" %}</label>
+          <input class="form-check-input" type="radio" name="interactive-rgb-mixer-colourCode" value="dec" id="interactive-rgb-mixer-dec-colour-code" checked>
+          <label class="form-check-label" for="interactive-rgb-mixer-dec-colour-code">{% trans "Decimal" %}</label>
       </div>
       <div class="form-check form-check-inline">
-          <input class="form-check-input" type="radio" name="colourCode" value="hex" id="hex-colour-code">
-          <label class="form-check-label" for="hex-colour-code">{% trans "Hexadecimal" %}</label>
+          <input class="form-check-input" type="radio" name="interactive-rgb-mixer-colourCode" value="hex" id="interactive-rgb-mixer-hex-colour-code">
+          <label class="form-check-label" for="interactive-rgb-mixer-hex-colour-code">{% trans "Hexadecimal" %}</label>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Proposed changes

Minor fix: The CMY and RGB colour mixers are meant to appear on the same page ([5.5](https://www.csfieldguide.org.nz/en/chapters/data-representation/images-and-colours/)), but the radio buttons for both interactives have the same names and IDs, contrary to most other elements in those interactives. This pull request gives the radio buttons different names and IDs, consistent with other elements, so that clicking a radio button in one interactive doesn't produce unexpected behaviours in the other.

### Checklist

- [x] I have read the contribution guidelines.
- [x]  **N/A** I have linked any relevant existing issues/suggestions in the description above (include `#???` in your description to reference an issue, where `???` is the issue number).
- [x] The pull request is requesting a merge into the `develop` branch.
- [x]  **N/A** I have added necessary documentation (if appropriate).
- [x]  **N/A** If I've added/modified/deleted a third-party system, I've updated the relevant license files.
- [x] **Previously** I have added myself to the 'Community Contributors' section of `csfieldguide/templates/appendices/contributors.html`
