### PR TITLE
fix: 'No interactives' note missing from interactives index page: software engineering

### DIFF
--- a/csfieldguide/interactives/views.py
+++ b/csfieldguide/interactives/views.py
@@ -1,5 +1,6 @@
 """Views for the interactives application."""
 
+from django.db.models import Prefetch
 from django.views import generic
 from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
@@ -34,7 +35,11 @@ class IndexView(generic.ListView):
             Dictionary of context data.
         """
         context = super(IndexView, self).get_context_data(**kwargs)
-        context["chapters"] = Chapter.objects.prefetch_related('interactives')
+        context["chapters"] = Chapter.objects.prefetch_related(
+             Prefetch(
+                 'interactives', 
+                 queryset=Interactive.objects.filter(is_interactive=True))
+        )
         return context
 
 

--- a/csfieldguide/interactives/views.py
+++ b/csfieldguide/interactives/views.py
@@ -37,7 +37,7 @@ class IndexView(generic.ListView):
         context = super(IndexView, self).get_context_data(**kwargs)
         context["chapters"] = Chapter.objects.prefetch_related(
              Prefetch(
-                 'interactives', 
+                 'interactives',
                  queryset=Interactive.objects.filter(is_interactive=True))
         )
         return context


### PR DESCRIPTION
## Proposed changes

https://github.com/uccser/cs-field-guide/issues/1181
