### PR TITLE
Improve pixel viewer interactive's UI clarity

### DIFF
--- a/csfieldguide/locale/en/LC_MESSAGES/djangojs.po
+++ b/csfieldguide/locale/en/LC_MESSAGES/djangojs.po
@@ -1375,6 +1375,11 @@ msgstr ""
 msgid "Your image has been resized for this interactive to "
 msgstr ""
 
+#: static/interactives/pixel-viewer/js/pixel-viewer.js:1156
+#: static/interactives/pixel-viewer/js/pixel-viewer.js:1162
+msgid "Click to Zoom"
+msgstr ""
+
 #: static/interactives/python-interpreter/js/python-interpreter.js:5
 msgid "Welcome to computer programming, student"
 msgstr ""

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -74,6 +74,15 @@ var colour_code_rep = 'rgb';
 $( document ).ready(function() {
   init_cache(300, MAX_HEIGHT);
 
+  // Enable tooltips.
+  $('[data-toggle="tooltip"]').tooltip();
+  // Hide tooltips 2 seconds after being shown.
+  $('[data-toggle="tooltip"]').on('shown.bs.tooltip', function () {
+    setTimeout(function() {
+      $('[data-toggle="tooltip"]').tooltip('hide');
+    }, 2000);
+  });
+
   if (searchParameters.has('image')){
     image_filename = searchParameters.get('image');
   }
@@ -178,6 +187,7 @@ $( document ).ready(function() {
         scroller.scrollTo(scroller_position_left, scroller_position_top);
         $("#pixel-viewer-interactive-loader").hide();
         $("#pixel-viewer-interactive-buttons").css({opacity: 0, visibility: "visible"}).animate({opacity: 1}, 'slow');
+        $(zoomInBtn).tooltip('show');
       }
     );
     $("#pixel-viewer-interactive-original-image").fadeOut(300);
@@ -1141,13 +1151,20 @@ if (searchParameters.has('no-pixel-fill')) {
 
 window.addEventListener("resize", reflow, false);
 
-document.querySelector("#pixel-viewer-interactive-zoom-in").addEventListener("click", function() {
+// Setup button tooltips.
+const zoomInBtn = document.querySelector("#pixel-viewer-interactive-zoom-in");
+zoomInBtn.title = gettext("Click to Zoom");
+zoomInBtn.addEventListener("click", function() {
   scroller.zoomBy(1.2, true);
 }, false);
 
-document.querySelector("#pixel-viewer-interactive-zoom-out").addEventListener("click", function() {
+zoomOutBtn = document.querySelector("#pixel-viewer-interactive-zoom-out");
+zoomOutBtn.title = gettext("Click to Zoom");
+zoomOutBtn.addEventListener("click", function() {
   scroller.zoomBy(0.8, true);
 }, false);
+// If user tries to zoom, show tooltips.
+window.addEventListener("resize", showTooltips, false);
 
 if ('ontouchstart' in window) {
 
@@ -1247,4 +1264,9 @@ function sum(array){
   return array.reduce(function(prev, curr, currI, arr){
     return prev + curr;
   });
+}
+
+function showTooltips() {
+  $(zoomInBtn).tooltip('show');
+  $(zoomOutBtn).tooltip('show');
 }

--- a/csfieldguide/templates/interactives/pixel-viewer.html
+++ b/csfieldguide/templates/interactives/pixel-viewer.html
@@ -6,10 +6,34 @@
 {% block interactive_html %}
     <div id="pixel-viewer-interactive" class="d-flex flex-column">
         <div id="pixel-viewer-interactive-buttons" class="flex-shrink-0">
-            <button id="pixel-viewer-interactive-zoom-in" class="btn btn-primary btn-lg flex-fill zoom-button">
+            <button id="pixel-viewer-interactive-zoom-in"
+                class="btn btn-primary btn-lg flex-fill zoom-button"
+                data-toggle="tooltip"
+                data-placement="bottom"
+                data-trigger="manual"
+                title=""
+                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-zoom-in" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11M13 6.5a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0"/>
+                    <path d="M10.344 11.742q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1 6.5 6.5 0 0 1-1.398 1.4z"/>
+                    <path fill-rule="evenodd" d="M6.5 3a.5.5 0 0 1 .5.5V6h2.5a.5.5 0 0 1 0 1H7v2.5a.5.5 0 0 1-1 0V7H3.5a.5.5 0 0 1 0-1H6V3.5a.5.5 0 0 1 .5-.5"/>
+                </svg>
+                <!-- From Bootstrap Icons -->
                 {% trans "Zoom In" %}
             </button>
-            <button id="pixel-viewer-interactive-zoom-out" class="btn btn-primary btn-lg flex-fill zoom-button">
+            <button id="pixel-viewer-interactive-zoom-out"
+            class="btn btn-primary btn-lg flex-fill zoom-button"
+            data-toggle="tooltip"
+            data-placement="bottom"
+            data-trigger="manual"
+            title=""
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-zoom-out" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11M13 6.5a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0"/>
+                    <path d="M10.344 11.742q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1 6.5 6.5 0 0 1-1.398 1.4z"/>
+                    <path fill-rule="evenodd" d="M3 6.5a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 0 1h-6a.5.5 0 0 1-.5-.5"/>
+                </svg>
+                <!-- From Bootstrap Icons -->
                 {% trans "Zoom Out" %}
             </button>
             <button id="pixel-viewer-interactive-menu-toggle" class="btn btn-primary btn-lg flex-fill">


### PR DESCRIPTION
## Proposed changes

- Make tool tips for zoom buttons
- Tool tip visible on button show to direct user towards them
- When resize happens, re-show tool tips
- Add icons for Zoom In and Zoom Out

https://github.com/uccser/cs-field-guide/issues/788