### PR TITLE
3.15.1

### DIFF
--- a/csfieldguide/config/__init__.py
+++ b/csfieldguide/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "3.15.0"
+__version__ = "3.15.1"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,7 +35,6 @@ We have listed major changes for each release below.
     - Update selenium from 4.20.0 to 4.21.0
     - Update lxml from 5.2.1 to 5.2.2
     - Update django-modeltranslation from 0.18.12 to 0.18.13
-    - 
 
 - Interactive cmy-mixer Dependency changes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,53 @@ All notable changes to this project will be documented in this file.
 We have listed major changes for each release below.
 `All downloads are available on GitHub <https://github.com/uccser/cs-field-guide/releases/>`__
 
+3.15.1
+==============================================================================
+
+**Release date:** 22nd May 2024
+
+**Changelog:**
+
+- Update docker images to use debian bookworm
+- Update docker images to python 3.11
+- Core Dependency changes:
+
+    - Update crowdin/github-action from 1.20.2 to 1..20.4
+    - Update iframe-resizer from 4.3.11 to 4.4.0
+    - Update sass from 1.77.0 to 1.77.2
+    - Update selenium from 4.20.0 to 4.21.0
+    - Update lxml from 5.2.1 to 5.2.2
+    - Update django-modeltranslation from 0.18.12 to 0.18.13
+    - 
+
+- Interactive cmy-mixer Dependency changes:
+
+    - Update nouislider from 15.7.1 to 15.7.2
+
+- Interactive colour-matcher Dependency changes:
+
+    - Update nouislider from 15.7.1 to 15.7.2
+
+- Interactive data-bias Dependency changes:
+
+    - Update nouislider from 15.7.1 to 15.7.2
+
+- Interactive data-visualisation Dependency changes:
+
+    - Update chart.js from 4.4.2 to 4.4.3
+
+- Interactive frequency-analysis Dependency changes:
+
+    - Update chart.js from 4.4.2 to 4.4.3
+
+- Interactive rgb-mixer Dependency changes:
+
+    - Update nouislider from 15.7.1 to 15.7.2
+
+- Interactive training-ground Dependency changes:
+
+    - Update nouislider from 15.7.1 to 15.7.2
+
 3.15.0
 ==============================================================================
 


### PR DESCRIPTION
**Release date:** 22nd May 2024

**Changelog:**

- Update docker images to use debian bookworm
- Update docker images to python 3.11
- Core Dependency changes:

    - Update crowdin/github-action from 1.20.2 to 1..20.4
    - Update iframe-resizer from 4.3.11 to 4.4.0
    - Update sass from 1.77.0 to 1.77.2
    - Update selenium from 4.20.0 to 4.21.0
    - Update lxml from 5.2.1 to 5.2.2
    - Update django-modeltranslation from 0.18.12 to 0.18.13

- Interactive cmy-mixer Dependency changes:

    - Update nouislider from 15.7.1 to 15.7.2

- Interactive colour-matcher Dependency changes:

    - Update nouislider from 15.7.1 to 15.7.2

- Interactive data-bias Dependency changes:

    - Update nouislider from 15.7.1 to 15.7.2

- Interactive data-visualisation Dependency changes:

    - Update chart.js from 4.4.2 to 4.4.3

- Interactive frequency-analysis Dependency changes:

    - Update chart.js from 4.4.2 to 4.4.3

- Interactive rgb-mixer Dependency changes:

    - Update nouislider from 15.7.1 to 15.7.2

- Interactive training-ground Dependency changes:

    - Update nouislider from 15.7.1 to 15.7.2