### PR TITLE
Add binary to pixel viewer. Resolves #2995

### DIFF
--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -49,7 +49,7 @@
     ],
     "scripts": {
         "dev": "gulp",
-        "generate-assets": "gulp generate-assets",
-        "build": "gulp generate-assets --production"
+        "generate-assets": "gulp generate-assets --no-experimental-require-module",
+        "build": "gulp generate-assets --production --no-experimental-require-module"
     }
 }

--- a/csfieldguide/static/interactives/pixel-viewer/README.md
+++ b/csfieldguide/static/interactives/pixel-viewer/README.md
@@ -25,6 +25,7 @@ The interactive has the following optional parameters to configure the interacti
   - `rgb-hex` - Shows the colour of the pixel in RGB format using Hexadecimal.
   - `hex` - Shows the colour of the pixel in Hexadecimal format.
   - `brightness` - Shows the brightness (i.e greyscale value) of the pixel as a value up to 255.
+  - `binary` - Show the colour of the pixel in RGB format using Binary.  
 
 - `image` - Filename of image to use (for example `arnold.jpg`).
 - `picturepicker` - Displays a set of pictures available for using.

--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -139,6 +139,8 @@ $( document ).ready(function() {
     $("input[id='rgb-hex-colour-code']").prop('checked', true);
   } else if (colour_code_rep == 'hex') {
     $("input[id='hex-colour-code']").prop('checked', true);
+  } else if (colour_code_rep == 'binary') {
+    $("input[id='binary-colour-code']").prop('checked', true);
   } else if (colour_code_rep == 'brightness') {
     $("input[id='brightness-colour-code']").prop('checked', true);
   } else {
@@ -1112,6 +1114,9 @@ var paint = function(row, col, left, top, width, height, zoom) {
       for (var i = 0; i < cell_lines.length; i++) {
         if (colour_code_rep == 'rgb-hex') { // Shows colour codes in RGB using Hexadecimal
           value = componentToHex(pixelData[i])
+        } else if (colour_code_rep == 'binary'){
+            context.font = (7 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
+            value = decTobinary(pixelData[i])
         } else { // Shows colour codes in RGB using Decimal
           value = pixelData[i]
         }
@@ -1129,6 +1134,10 @@ function componentToHex(c) {
 
 function rgbToHex(r, g, b) {
   return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+}
+
+function decTobinary(dec){
+    return (dec >>> 0).toString(2).padStart(8, '0');
 }
 
 var rect = container.getBoundingClientRect();

--- a/csfieldguide/templates/appendices/contributors.html
+++ b/csfieldguide/templates/appendices/contributors.html
@@ -30,7 +30,7 @@
     </li>
     <li>Arpo Deer, Kāi Tahu ki Te Pātaka o Rākaihautū</li>
   </ul>
-  
+
   <h2 id="writers"><a href="#writers">{% trans 'Writers' %}</a></h2>
   <ul>
     <li>Tim Bell - {% trans 'Formal Languages, Compression, Human Computer Interaction, and Coding Introduction' %}</li>
@@ -136,6 +136,7 @@
 
   <h2 id="community-contributors"><a href="#community-contributors">{% trans 'Community Contributors' %}</a></h2>
   <ul>
+    <li><a href="https://https://github.com/MrWardKKHS">MrWardKKHS</a> (Alex Ward)</li>
     <li><a href="https://github.com/ArloL">ArloL</a> (Arlo Louis O'Keeffe)</li>
     <li><a href="https://github.com/0xcpu">ner0x652</a> (Cornel Punga)</li>
     <li><a href="https://github.com/alanhogan">alanhogan</a> (Alan Hogan)</li>

--- a/csfieldguide/templates/interactives/pixel-viewer.html
+++ b/csfieldguide/templates/interactives/pixel-viewer.html
@@ -82,6 +82,10 @@
                         <input class="form-check-input" type="radio" name="colourCode" value="brightness" id="brightness-colour-code">
                         <label class="form-check-label" for="brightness-colour-code">{% trans "Brightness (average)" %}</label>
                     </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" name="colourCode" value="binary" id="binary-colour-code">
+                        <label class="form-check-label" for="binary-colour-code">{% trans "Binary (seperate RGB)" %}</label>
+                    </div>
                 </div>
                 <div class="dropdown">
                     <button class="btn btn-secondary dropdown-toggle" type="button" id="configSelector" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/dev
+++ b/dev
@@ -86,7 +86,7 @@ cmd_update() {
   cmd_collect_static
 
   echo -e "\n${SUCCESS}Content is loaded!${NC}"
-  echo "Open your preferred web browser to the URL 'cs-field-guide.localhost'"
+  echo "Open your preferred web browser to the URL 'http://localhost:8000'"
 }
 defhelp update 'Run Django migrate and update_data commands and build static files.'
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -15,8 +15,10 @@ services:
             - ./infrastructure/local/postgres/.envs
         command: /start
         networks:
-            - uccser-development-stack
             - backend
+
+        ports:
+            - "8000:8000"
         labels:
             # General labels
             - "traefik.enable=true"
@@ -105,8 +107,6 @@ services:
         image: ghcr.io/uccser/local-docs-image:latest
         volumes:
             - ./docs:/docs:z
-        networks:
-            - uccser-development-stack
         labels:
             # General labels
             - "traefik.enable=true"


### PR DESCRIPTION
## Proposed changes
Resolves #2995 
Pixel viewer should have a binary representation to allow for more utility from this interactive in a normal sequence of lessons around data representation. This will help teachers get more use out of this as image representation often follows shortly after number representation and text representation which centers around 8 bit binary codes. 

### Checklist

*Change the space in the box to an `x` for those you have completed.
You can also fill these out after creating the pull request.
If you're unsure about any of them, don't hesitate to ask.
We're here to help!
This is simply a reminder of what we are going to look for before merging your change.*

- [x] I have read the contribution guidelines.
- [x] I have linked any relevant existing issues/suggestions in the description above (include `#???` in your description to reference an issue, where `???` is the issue number).
- [x] The pull request is requesting a merge into the `develop` branch.
- [x] I have added necessary documentation (if appropriate).
- [x] If I've added/modified/deleted a third-party system, I've updated the relevant license files.
- [x] I have added myself to the 'Community Contributors' section of `csfieldguide/templates/appendices/contributors.html`

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
Feel free to add any images that might be helpful to understand the initial problem/solution.
