### PR TITLE
feat: add binary to pixel viewer

### DIFF
--- a/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
+++ b/csfieldguide/static/interactives/pixel-viewer/js/pixel-viewer.js
@@ -139,6 +139,8 @@ $( document ).ready(function() {
     $("input[id='rgb-hex-colour-code']").prop('checked', true);
   } else if (colour_code_rep == 'hex') {
     $("input[id='hex-colour-code']").prop('checked', true);
+  } else if (colour_code_rep == 'binary') {
+    $("input[id='binary-colour-code']").prop('checked', true);
   } else if (colour_code_rep == 'brightness') {
     $("input[id='brightness-colour-code']").prop('checked', true);
   } else {
@@ -1112,6 +1114,9 @@ var paint = function(row, col, left, top, width, height, zoom) {
       for (var i = 0; i < cell_lines.length; i++) {
         if (colour_code_rep == 'rgb-hex') { // Shows colour codes in RGB using Hexadecimal
           value = componentToHex(pixelData[i])
+        } else if (colour_code_rep == 'binary'){
+            context.font = (7 * zoom).toFixed(2) + 'px Consolas, Courier New, monospace';
+            value = decTobinary(pixelData[i])
         } else { // Shows colour codes in RGB using Decimal
           value = pixelData[i]
         }
@@ -1129,6 +1134,10 @@ function componentToHex(c) {
 
 function rgbToHex(r, g, b) {
   return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b);
+}
+
+function decTobinary(dec){
+    return (dec >>> 0).toString(2).padStart(8, '0');
 }
 
 var rect = container.getBoundingClientRect();

--- a/csfieldguide/templates/interactives/pixel-viewer.html
+++ b/csfieldguide/templates/interactives/pixel-viewer.html
@@ -82,6 +82,10 @@
                         <input class="form-check-input" type="radio" name="colourCode" value="brightness" id="brightness-colour-code">
                         <label class="form-check-label" for="brightness-colour-code">{% trans "Brightness (average)" %}</label>
                     </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" name="colourCode" value="binary" id="binary-colour-code">
+                        <label class="form-check-label" for="binary-colour-code">{% trans "Binary (seperate RGB)" %}</label>
+                    </div>
                 </div>
                 <div class="dropdown">
                     <button class="btn btn-secondary dropdown-toggle" type="button" id="configSelector" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request:

Proposed changes

Resolves #2995
Pixel viewer should have a binary representation to allow for more utility from this interactive in a normal sequence of lessons around data representation. This will help teachers get more use out of this as image representation often follows shortly after number representation and text representation which centers around 8 bit binary codes.
Checklist

### Checklist

*Change the space in the box to an `x` for those you have completed.
You can also fill these out after creating the pull request.
If you're unsure about any of them, don't hesitate to ask.
We're here to help!
This is simply a reminder of what we are going to look for before merging your change.*

- [x] I have read the contribution guidelines.
- [x] I have linked any relevant existing issues/suggestions in the description above (include `#???` in your description to reference an issue, where `???` is the issue number).
- [x] The pull request is requesting a merge into the `develop` branch.
- [x] I have added necessary documentation (if appropriate).
- [x] If I've added/modified/deleted a third-party system, I've updated the relevant license files.
- [x] I have added myself to the 'Community Contributors' section of `csfieldguide/templates/appendices/contributors.html`

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
Feel free to add any images that might be helpful to understand the initial problem/solution.
