### PR TITLE
Release/3.17.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directories:
+      - "/infrastructure/**/*"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 999
+  - package-ecosystem: "npm"
+    directory: "/csfieldguide/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 999
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 999
+    ignore:
+    # Ignore updates to Django package until LTS version
+      - dependency-name: "django"
+        versions: ["4.0.*", "4.1.*", "5.0.*", "5.1.*", "6.0.*", "6.1.*", "7.0.*", "7.1.*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 999

--- a/.github/workflows/crowdin-actions.yaml
+++ b/.github/workflows/crowdin-actions.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Upload or update source files to Crowdin
       uses: crowdin/github-action@v1.20.4

--- a/.github/workflows/crowdin-actions.yaml
+++ b/.github/workflows/crowdin-actions.yaml
@@ -58,3 +58,21 @@ jobs:
         pull_request_labels: 'internationalization'
         pull_request_base_branch_name: develop
         config: crowdin.yaml
+
+    - name: Download Te Reo Māori translations
+      uses: crowdin/github-action@v1.20.4
+      with:
+        upload_sources: false
+        download_translations: true
+        download_language: 'mi'
+        skip_untranslated_files: true
+        export_only_approved: true
+        push_translations: true
+        commit_message: 'Update Te Reo Māori Crowdin translations by Github Action'
+        localization_branch_name: translation-mi
+        create_pull_request: true
+        pull_request_title: 'Update Te Reo Māori language translations'
+        pull_request_body: 'This pull request will add/update Te Reo Māori language files from Crowdin.'
+        pull_request_labels: 'internationalization'
+        pull_request_base_branch_name: develop
+        config: crowdin.yaml

--- a/.github/workflows/crowdin-actions.yaml
+++ b/.github/workflows/crowdin-actions.yaml
@@ -19,12 +19,12 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Upload or update source files to Crowdin
-      uses: crowdin/github-action@v1.20.4
+      uses: crowdin/github-action@v2.16.0
       with:
         upload_sources: true
 
     - name: Download German translations
-      uses: crowdin/github-action@v1.20.4
+      uses: crowdin/github-action@v2.16.0
       with:
         upload_sources: false
         download_translations: true
@@ -42,7 +42,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Spanish translations
-      uses: crowdin/github-action@v1.20.4
+      uses: crowdin/github-action@v2.16.0
       with:
         upload_sources: false
         download_translations: true
@@ -60,7 +60,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Te Reo Māori translations
-      uses: crowdin/github-action@v1.20.4
+      uses: crowdin/github-action@v2.16.0
       with:
         upload_sources: false
         download_translations: true

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Create coverage file
         run: docker compose -f docker-compose.local.yml run --rm --user="root" django coverage xml -i
       - name: Upload coverage file
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ./csfieldguide/coverage.xml
           verbose: true
@@ -82,7 +82,7 @@ jobs:
       - name: Create coverage file
         run: docker compose -f docker-compose.local.yml run --rm --user="root" django coverage xml -i
       - name: Upload coverage file
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ./csfieldguide/coverage.xml
           verbose: true

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -258,7 +258,7 @@ jobs:
 
       - name: Setup Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -250,7 +250,7 @@ jobs:
           ls artifacts/interactive-thumbnails-*/interactive-thumbnails.tar.gz | xargs -n1 tar -xz --directory csfieldguide/staticfiles/img/interactives/thumbnails --file
 
       - name: Log in to ${{ env.REGISTRY }}
-        uses: docker/login-action@v3.4.0
+        uses: docker/login-action@v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -250,7 +250,7 @@ jobs:
           ls artifacts/interactive-thumbnails-*/interactive-thumbnails.tar.gz | xargs -n1 tar -xz --directory csfieldguide/staticfiles/img/interactives/thumbnails --file
 
       - name: Log in to ${{ env.REGISTRY }}
-        uses: docker/login-action@v4.0.0
+        uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Create Docker network
         run: docker network create uccser-development-stack
         # Required for the node service
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Create Docker network
         run: docker network create uccser-development-stack
         # Required for the node service
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run general tests
         run: ./dev ci test_general
       - name: Create coverage file
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run management tests
         run: ./dev ci test_management
       - name: Create coverage file
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run style tests
         run: ./dev ci style
 
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -131,7 +131,7 @@ jobs:
     ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create Docker network
         run: docker network create uccser-development-stack
@@ -182,7 +182,7 @@ jobs:
     ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create Docker network
         run: docker network create uccser-development-stack
@@ -232,7 +232,7 @@ jobs:
     ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -266,7 +266,7 @@ jobs:
             type=ref,event=branch,priority=2
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5.4.0
+        uses: docker/build-push-action@v7.0.0
         with:
           file: ./infrastructure/production/django/Dockerfile
           context: .

--- a/csfieldguide/config/__init__.py
+++ b/csfieldguide/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "3.16.0"
+__version__ = "3.17.0"

--- a/csfieldguide/config/settings/base.py
+++ b/csfieldguide/config/settings/base.py
@@ -329,6 +329,9 @@ SVG_DIRS = [os.path.join(str(ROOT_DIR.path("staticfiles")), "svg")]
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 X_FRAME_OPTIONS = "SAMEORIGIN"
 
+# Required for youtube embeds to work
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+
 CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:8000",
     "http://localhost:8000",

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -8575,11 +8575,10 @@
             }
         },
         "node_modules/immutable": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-            "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+            "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12476,9 +12475,9 @@
             }
         },
         "node_modules/sass/node_modules/immutable": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.2.tgz",
-            "integrity": "sha512-1NU7hWZDkV7hJ4PJ9dur9gTNQ4ePNPN4k9/0YhwjzykTi/+3Q5pF93YU5QoVj8BuOnhLgaY8gs0U2pj4kSYVcw==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
             "dev": true
         },
         "node_modules/sass/node_modules/readdirp": {
@@ -21275,9 +21274,9 @@
             }
         },
         "immutable": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-            "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+            "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
             "dev": true
         },
         "import-lazy": {
@@ -24173,9 +24172,9 @@
                     }
                 },
                 "immutable": {
-                    "version": "5.0.2",
-                    "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.2.tgz",
-                    "integrity": "sha512-1NU7hWZDkV7hJ4PJ9dur9gTNQ4ePNPN4k9/0YhwjzykTi/+3Q5pF93YU5QoVj8BuOnhLgaY8gs0U2pj4kSYVcw==",
+                    "version": "5.1.5",
+                    "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+                    "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
                     "dev": true
                 },
                 "readdirp": {

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -10818,9 +10818,9 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "engines": {
                 "node": ">=8.6"
@@ -23025,9 +23025,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true
         },
         "pify": {

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -39,7 +39,7 @@
                 "multiple-select": "1.7.0",
                 "pixrem": "5.0.0",
                 "popper.js": "1.16.1",
-                "postcss": "8.5.6",
+                "postcss": "8.5.8",
                 "postcss-flexbugs-fixes": "5.0.2",
                 "sass": "1.89.2",
                 "vinyl-buffer": "1.0.1",
@@ -10986,9 +10986,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
             "dev": true,
             "funding": [
                 {
@@ -11004,7 +11004,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -23140,9 +23139,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.3.11",

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -12786,16 +12786,23 @@
             "dev": true
         },
         "node_modules/sha.js": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
             "dev": true,
             "dependencies": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
             },
             "bin": {
                 "sha.js": "bin.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/shasum-object": {
@@ -24424,13 +24431,14 @@
             "dev": true
         },
         "sha.js": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
             }
         },
         "shasum-object": {

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -33,7 +33,7 @@
                 "gulp-sourcemaps": "3.0.0",
                 "gulp-tap": "2.0.0",
                 "gulp-terser": "2.1.0",
-                "iframe-resizer": "4.4.5",
+                "iframe-resizer": "5.5.9",
                 "jquery": "3.7.1",
                 "lity": "2.4.1",
                 "multiple-select": "1.7.0",
@@ -1769,6 +1769,59 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/@iframe-resizer/child": {
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/@iframe-resizer/child/-/child-5.5.9.tgz",
+            "integrity": "sha512-kX4GeGvlfu9S0XfDgSEy+O36q6qFz17kslLYdBT1evBTCK7Q3ETYtZMzVnHlB5PKc9co699kWEZbmpUGtE9IQw==",
+            "dev": true,
+            "dependencies": {
+                "auto-console-group": "1.3.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://iframe-resizer.com/pricing/"
+            }
+        },
+        "node_modules/@iframe-resizer/core": {
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/@iframe-resizer/core/-/core-5.5.9.tgz",
+            "integrity": "sha512-HacDQx81pgHlmY48tRogcX02TOXfvjllJzI+xfVYmvEXhxoViyi9yEobhNQEt8Mq6NmrH1vHhz6FRfQ9uBTsjQ==",
+            "dev": true,
+            "dependencies": {
+                "auto-console-group": "1.3.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://iframe-resizer.com/pricing/"
+            }
+        },
+        "node_modules/@iframe-resizer/jquery": {
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/@iframe-resizer/jquery/-/jquery-5.5.9.tgz",
+            "integrity": "sha512-ihGJOv7K3tWT+HjLRKcM+9USqo7B3nrN8J5YEBH1Br+45E36uKeUq0JSrPckv9TFdjB0Xqc+le2f33lfrsRuAg==",
+            "dev": true,
+            "dependencies": {
+                "@iframe-resizer/core": "5.5.9"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://iframe-resizer.com/pricing/"
+            }
+        },
+        "node_modules/@iframe-resizer/parent": {
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/@iframe-resizer/parent/-/parent-5.5.9.tgz",
+            "integrity": "sha512-DfNb9KlOf7WyCNOM2xWPGxJfWtqA/gg7sjHvqvD4k6cfpntPXrKfCd3WdOPNKA980urGkhOdM9Ye0unV2gnYYw==",
+            "dev": true,
+            "dependencies": {
+                "@iframe-resizer/core": "5.5.9",
+                "auto-console-group": "1.3.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://iframe-resizer.com/pricing/"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -2669,6 +2722,12 @@
             "engines": {
                 "node": ">= 4.5.0"
             }
+        },
+        "node_modules/auto-console-group": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/auto-console-group/-/auto-console-group-1.3.0.tgz",
+            "integrity": "sha512-W/G5jy1ZPeVYPyqOVGND7EjbzrsLgRD3s+1QegXfJ7bYlphFxjqG60rviFXWw0d2YCj0Clc7hU5/nTqrBEhBIw==",
+            "dev": true
         },
         "node_modules/autoprefixer": {
             "version": "10.4.21",
@@ -8282,17 +8341,18 @@
             ]
         },
         "node_modules/iframe-resizer": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.4.5.tgz",
-            "integrity": "sha512-U8bCywf/Gh07O69RXo6dXAzTtODQrxaHGHRI7Nt4ipXsuq6EMxVsOP/jjaP43YtXz/ibESS0uSVDN3sOGCzSmw==",
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-5.5.9.tgz",
+            "integrity": "sha512-PpzCs5rBzNJFa7agEw8Q46sxDy1SrRAZEznpqP9KxWeL6ea895Xlv90fVswozey7Jzldzi2eeNqg2FMZ0Lfjrw==",
             "dev": true,
-            "hasInstallScript": true,
-            "engines": {
-                "node": ">=0.8.0"
+            "dependencies": {
+                "@iframe-resizer/child": "5.5.9",
+                "@iframe-resizer/jquery": "5.5.9",
+                "@iframe-resizer/parent": "5.5.9"
             },
             "funding": {
                 "type": "individual",
-                "url": "https://iframe-resizer.com//pricing"
+                "url": "https://iframe-resizer.com/pricing/"
             }
         },
         "node_modules/ignore": {
@@ -16044,6 +16104,43 @@
                 }
             }
         },
+        "@iframe-resizer/child": {
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/@iframe-resizer/child/-/child-5.5.9.tgz",
+            "integrity": "sha512-kX4GeGvlfu9S0XfDgSEy+O36q6qFz17kslLYdBT1evBTCK7Q3ETYtZMzVnHlB5PKc9co699kWEZbmpUGtE9IQw==",
+            "dev": true,
+            "requires": {
+                "auto-console-group": "1.3.0"
+            }
+        },
+        "@iframe-resizer/core": {
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/@iframe-resizer/core/-/core-5.5.9.tgz",
+            "integrity": "sha512-HacDQx81pgHlmY48tRogcX02TOXfvjllJzI+xfVYmvEXhxoViyi9yEobhNQEt8Mq6NmrH1vHhz6FRfQ9uBTsjQ==",
+            "dev": true,
+            "requires": {
+                "auto-console-group": "1.3.0"
+            }
+        },
+        "@iframe-resizer/jquery": {
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/@iframe-resizer/jquery/-/jquery-5.5.9.tgz",
+            "integrity": "sha512-ihGJOv7K3tWT+HjLRKcM+9USqo7B3nrN8J5YEBH1Br+45E36uKeUq0JSrPckv9TFdjB0Xqc+le2f33lfrsRuAg==",
+            "dev": true,
+            "requires": {
+                "@iframe-resizer/core": "5.5.9"
+            }
+        },
+        "@iframe-resizer/parent": {
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/@iframe-resizer/parent/-/parent-5.5.9.tgz",
+            "integrity": "sha512-DfNb9KlOf7WyCNOM2xWPGxJfWtqA/gg7sjHvqvD4k6cfpntPXrKfCd3WdOPNKA980urGkhOdM9Ye0unV2gnYYw==",
+            "dev": true,
+            "requires": {
+                "@iframe-resizer/core": "5.5.9",
+                "auto-console-group": "1.3.0"
+            }
+        },
         "@jridgewell/gen-mapping": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -16631,6 +16728,12 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
+        "auto-console-group": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/auto-console-group/-/auto-console-group-1.3.0.tgz",
+            "integrity": "sha512-W/G5jy1ZPeVYPyqOVGND7EjbzrsLgRD3s+1QegXfJ7bYlphFxjqG60rviFXWw0d2YCj0Clc7hU5/nTqrBEhBIw==",
             "dev": true
         },
         "autoprefixer": {
@@ -21075,10 +21178,15 @@
             "dev": true
         },
         "iframe-resizer": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.4.5.tgz",
-            "integrity": "sha512-U8bCywf/Gh07O69RXo6dXAzTtODQrxaHGHRI7Nt4ipXsuq6EMxVsOP/jjaP43YtXz/ibESS0uSVDN3sOGCzSmw==",
-            "dev": true
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-5.5.9.tgz",
+            "integrity": "sha512-PpzCs5rBzNJFa7agEw8Q46sxDy1SrRAZEznpqP9KxWeL6ea895Xlv90fVswozey7Jzldzi2eeNqg2FMZ0Lfjrw==",
+            "dev": true,
+            "requires": {
+                "@iframe-resizer/child": "5.5.9",
+                "@iframe-resizer/jquery": "5.5.9",
+                "@iframe-resizer/parent": "5.5.9"
+            }
         },
         "ignore": {
             "version": "5.3.1",

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "devDependencies": {
                 "@babel/core": "^7.27.7",
-                "@babel/preset-env": "^7.27.2",
+                "@babel/preset-env": "^7.29.2",
                 "ansi-colors": "4.1.3",
                 "autoprefixer": "10.4.21",
                 "babelify": "^10.0.0",
@@ -63,13 +63,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -85,11 +84,10 @@
             "license": "ISC"
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
-            "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -163,15 +161,15 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.27.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-            "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
             "dev": true,
             "dependencies": {
-                "@babel/parser": "^7.27.5",
-                "@babel/types": "^7.27.3",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             },
             "engines": {
@@ -179,26 +177,24 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz",
-            "integrity": "sha512-WnuuDILl9oOBbKnb4L+DyODx7iC47XfzmNCpTttFsSp6hTG7XZxu60+4IO+2/hPfcGOoKbFiwoI/+zwARbNQow==",
+            "version": "7.27.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.1"
+                "@babel/types": "^7.27.3"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.27.2",
+                "@babel/compat-data": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
@@ -233,18 +229,17 @@
             "dev": true
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-            "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+            "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-member-expression-to-functions": "^7.28.5",
                 "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.28.6",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/traverse": "^7.27.1",
+                "@babel/traverse": "^7.28.6",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -259,20 +254,18 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
-            "integrity": "sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+            "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "regexpu-core": "^6.2.0",
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "regexpu-core": "^6.3.1",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -292,29 +285,28 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
-            "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+            "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.22.6",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "debug": "^4.1.1",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "debug": "^4.4.3",
                 "lodash.debounce": "^4.0.8",
-                "resolve": "^1.14.2"
+                "resolve": "^1.22.11"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -326,49 +318,55 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
-        "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-            "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
             "dev": true,
-            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-member-expression-to-functions": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+            "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+            "dev": true,
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.28.5",
+                "@babel/types": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-            "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.27.3"
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -391,11 +389,10 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -405,7 +402,6 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
             "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.27.1",
                 "@babel/helper-wrap-function": "^7.27.1",
@@ -419,15 +415,14 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-            "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+            "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-member-expression-to-functions": "^7.28.5",
                 "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/traverse": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -461,11 +456,10 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -481,15 +475,14 @@
             }
         },
         "node_modules/@babel/helper-wrap-function": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
-            "integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+            "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.1",
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -509,12 +502,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.7.tgz",
-            "integrity": "sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.27.7"
+                "@babel/types": "^7.29.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -524,14 +517,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
-            "integrity": "sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+            "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/traverse": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -591,14 +583,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
-            "integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+            "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/traverse": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -620,13 +611,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
-            "integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+            "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -636,13 +626,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-            "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+            "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -684,15 +673,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
-            "integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+            "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-remap-async-to-generator": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/traverse": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -702,14 +690,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
-            "integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+            "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-remap-async-to-generator": "^7.27.1"
             },
             "engines": {
@@ -736,13 +723,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.1.tgz",
-            "integrity": "sha512-QEcFlMl9nGTgh1rn2nIeU5bkfb9BAjaQcWbiP4LvKxUot52ABcTkpcyJ7f2Q2U2RuQ84BNLgts3jRme2dTx6Fw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+            "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -752,14 +738,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-properties": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
-            "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+            "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -769,14 +754,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-static-block": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
-            "integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+            "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -786,18 +770,17 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
-            "integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+            "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-compilation-targets": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1",
-                "@babel/traverse": "^7.27.1",
-                "globals": "^11.1.0"
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-replace-supers": "^7.28.6",
+                "@babel/traverse": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -807,14 +790,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
-            "integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+            "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/template": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/template": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -824,13 +806,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.1.tgz",
-            "integrity": "sha512-ttDCqhfvpE9emVkXbPD8vyxxh4TWYACVybGkDj+oReOGwnp066ITEivDlLwe0b1R0+evJ13IXQuLNB5w1fhC5Q==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+            "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/traverse": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -840,14 +822,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
-            "integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+            "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -873,14 +854,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
-            "integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+            "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -905,14 +885,29 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
-            "integrity": "sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==",
+        "node_modules/@babel/plugin-transform-explicit-resource-management": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+            "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/plugin-transform-destructuring": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+            "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -973,13 +968,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-json-strings": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
-            "integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+            "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1005,13 +999,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
-            "integrity": "sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+            "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1054,14 +1047,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-            "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+            "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1071,16 +1063,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
-            "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+            "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1107,14 +1098,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
-            "integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+            "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1140,13 +1130,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
-            "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+            "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1156,13 +1145,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-numeric-separator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
-            "integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+            "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1172,16 +1160,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-rest-spread": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.2.tgz",
-            "integrity": "sha512-AIUHD7xJ1mCrj3uPozvtngY3s0xpv7Nu7DoUSnzNY6Xam1Cy4rUznR//pvMHOhQ4AvbCexhbqXCtpxGHOGOO6g==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+            "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/plugin-transform-destructuring": "^7.27.1",
-                "@babel/plugin-transform-parameters": "^7.27.1"
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/plugin-transform-destructuring": "^7.28.5",
+                "@babel/plugin-transform-parameters": "^7.27.7",
+                "@babel/traverse": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1208,13 +1196,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-catch-binding": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
-            "integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+            "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1224,13 +1211,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
-            "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+            "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
             },
             "engines": {
@@ -1241,11 +1227,10 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
-            "integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+            "version": "7.27.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+            "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.27.1"
             },
@@ -1257,14 +1242,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-methods": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
-            "integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+            "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1274,15 +1258,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-property-in-object": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
-            "integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+            "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1308,13 +1291,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.1.tgz",
-            "integrity": "sha512-B19lbbL7PMrKr52BNPjCqg1IyNUIjTcxKj8uX9zHO+PmWN93s19NDr/f69mIkEp2x9nmDJ08a7lgHaTTzvW7mw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+            "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1324,14 +1306,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-regexp-modifiers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
-            "integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+            "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1373,13 +1354,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
-            "integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+            "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
             },
             "engines": {
@@ -1454,14 +1434,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-property-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
-            "integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+            "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1488,14 +1467,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
-            "integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+            "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1505,80 +1483,80 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
-            "integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+            "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.27.2",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/compat-data": "^7.29.0",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
+                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
                 "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
                 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
                 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
                 "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-                "@babel/plugin-syntax-import-assertions": "^7.27.1",
-                "@babel/plugin-syntax-import-attributes": "^7.27.1",
+                "@babel/plugin-syntax-import-assertions": "^7.28.6",
+                "@babel/plugin-syntax-import-attributes": "^7.28.6",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.27.1",
-                "@babel/plugin-transform-async-generator-functions": "^7.27.1",
-                "@babel/plugin-transform-async-to-generator": "^7.27.1",
+                "@babel/plugin-transform-async-generator-functions": "^7.29.0",
+                "@babel/plugin-transform-async-to-generator": "^7.28.6",
                 "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-                "@babel/plugin-transform-block-scoping": "^7.27.1",
-                "@babel/plugin-transform-class-properties": "^7.27.1",
-                "@babel/plugin-transform-class-static-block": "^7.27.1",
-                "@babel/plugin-transform-classes": "^7.27.1",
-                "@babel/plugin-transform-computed-properties": "^7.27.1",
-                "@babel/plugin-transform-destructuring": "^7.27.1",
-                "@babel/plugin-transform-dotall-regex": "^7.27.1",
+                "@babel/plugin-transform-block-scoping": "^7.28.6",
+                "@babel/plugin-transform-class-properties": "^7.28.6",
+                "@babel/plugin-transform-class-static-block": "^7.28.6",
+                "@babel/plugin-transform-classes": "^7.28.6",
+                "@babel/plugin-transform-computed-properties": "^7.28.6",
+                "@babel/plugin-transform-destructuring": "^7.28.5",
+                "@babel/plugin-transform-dotall-regex": "^7.28.6",
                 "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
                 "@babel/plugin-transform-dynamic-import": "^7.27.1",
-                "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
+                "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+                "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
                 "@babel/plugin-transform-export-namespace-from": "^7.27.1",
                 "@babel/plugin-transform-for-of": "^7.27.1",
                 "@babel/plugin-transform-function-name": "^7.27.1",
-                "@babel/plugin-transform-json-strings": "^7.27.1",
+                "@babel/plugin-transform-json-strings": "^7.28.6",
                 "@babel/plugin-transform-literals": "^7.27.1",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
                 "@babel/plugin-transform-member-expression-literals": "^7.27.1",
                 "@babel/plugin-transform-modules-amd": "^7.27.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-                "@babel/plugin-transform-modules-systemjs": "^7.27.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.28.6",
+                "@babel/plugin-transform-modules-systemjs": "^7.29.0",
                 "@babel/plugin-transform-modules-umd": "^7.27.1",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
                 "@babel/plugin-transform-new-target": "^7.27.1",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-                "@babel/plugin-transform-numeric-separator": "^7.27.1",
-                "@babel/plugin-transform-object-rest-spread": "^7.27.2",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+                "@babel/plugin-transform-numeric-separator": "^7.28.6",
+                "@babel/plugin-transform-object-rest-spread": "^7.28.6",
                 "@babel/plugin-transform-object-super": "^7.27.1",
-                "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
-                "@babel/plugin-transform-optional-chaining": "^7.27.1",
-                "@babel/plugin-transform-parameters": "^7.27.1",
-                "@babel/plugin-transform-private-methods": "^7.27.1",
-                "@babel/plugin-transform-private-property-in-object": "^7.27.1",
+                "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+                "@babel/plugin-transform-optional-chaining": "^7.28.6",
+                "@babel/plugin-transform-parameters": "^7.27.7",
+                "@babel/plugin-transform-private-methods": "^7.28.6",
+                "@babel/plugin-transform-private-property-in-object": "^7.28.6",
                 "@babel/plugin-transform-property-literals": "^7.27.1",
-                "@babel/plugin-transform-regenerator": "^7.27.1",
-                "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+                "@babel/plugin-transform-regenerator": "^7.29.0",
+                "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
                 "@babel/plugin-transform-reserved-words": "^7.27.1",
                 "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-                "@babel/plugin-transform-spread": "^7.27.1",
+                "@babel/plugin-transform-spread": "^7.28.6",
                 "@babel/plugin-transform-sticky-regex": "^7.27.1",
                 "@babel/plugin-transform-template-literals": "^7.27.1",
                 "@babel/plugin-transform-typeof-symbol": "^7.27.1",
                 "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-                "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+                "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
                 "@babel/plugin-transform-unicode-regex": "^7.27.1",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
-                "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.11.0",
-                "babel-plugin-polyfill-regenerator": "^0.6.1",
-                "core-js-compat": "^3.40.0",
+                "babel-plugin-polyfill-corejs2": "^0.4.15",
+                "babel-plugin-polyfill-corejs3": "^0.14.0",
+                "babel-plugin-polyfill-regenerator": "^0.6.6",
+                "core-js-compat": "^3.48.0",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -1612,33 +1590,32 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/parser": "^7.27.2",
-                "@babel/types": "^7.27.1"
+                "@babel/code-frame": "^7.28.6",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.7.tgz",
-            "integrity": "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.27.5",
-                "@babel/parser": "^7.27.7",
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.7",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1668,13 +1645,13 @@
             "dev": true
         },
         "node_modules/@babel/types": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.7.tgz",
-            "integrity": "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1"
+                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1770,32 +1747,19 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
             "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-            "dev": true,
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -1812,15 +1776,15 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -2732,13 +2696,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.10",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.10.tgz",
-            "integrity": "sha512-rpIuu//y5OX6jVU+a5BCn1R5RSZYWAl2Nar76iwaOdycqb6JPxediskWFMMl7stfwNJR4b7eiQvh5fB5TEQJTQ==",
+            "version": "0.4.17",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+            "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.22.6",
-                "@babel/helper-define-polyfill-provider": "^0.6.1",
+                "@babel/compat-data": "^7.28.6",
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -2755,26 +2719,25 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-            "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+            "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.3",
-                "core-js-compat": "^3.40.0"
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
+                "core-js-compat": "^3.48.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.1.tgz",
-            "integrity": "sha512-JfTApdE++cgcTWjsiCQlLyFBMbTUft9ja17saCc93lgV33h4tuCVj7tlvu//qpLwaG+3yEz7/KhahGrUMkVq9g==",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+            "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.1"
+                "@babel/helper-define-polyfill-provider": "^0.6.8"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2913,6 +2876,18 @@
             "dev": true,
             "engines": {
                 "node": "^4.5.0 || >= 5.9"
+            }
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.12",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+            "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+            "dev": true,
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/batch": {
@@ -3595,9 +3570,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.24.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-            "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
             "funding": [
                 {
@@ -3613,12 +3588,12 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001716",
-                "electron-to-chromium": "^1.5.149",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.3"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -3897,9 +3872,9 @@
             "license": "MIT"
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001717",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-            "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+            "version": "1.0.30001782",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+            "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
             "dev": true,
             "funding": [
                 {
@@ -3914,8 +3889,7 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ],
-            "license": "CC-BY-4.0"
+            ]
         },
         "node_modules/caw": {
             "version": "2.0.1",
@@ -4353,13 +4327,12 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.40.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
-            "integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+            "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.3"
+                "browserslist": "^4.28.1"
             },
             "funding": {
                 "type": "opencollective",
@@ -5355,11 +5328,10 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.150",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz",
-            "integrity": "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==",
-            "dev": true,
-            "license": "ISC"
+            "version": "1.5.329",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
+            "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
+            "dev": true
         },
         "node_modules/elliptic": {
             "version": "6.6.1",
@@ -7166,15 +7138,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/globals": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/globby": {
             "version": "14.0.1",
             "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
@@ -7932,18 +7895,6 @@
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
             }
         },
         "node_modules/has-flag": {
@@ -8777,12 +8728,15 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
             "dev": true,
             "dependencies": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9181,9 +9135,9 @@
             "dev": true
         },
         "node_modules/jsesc": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
@@ -10104,11 +10058,10 @@
             "optional": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "2.0.36",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+            "dev": true
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -12083,15 +12036,13 @@
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
             "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/regenerate-unicode-properties": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
-            "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+            "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "regenerate": "^1.4.2"
             },
@@ -12113,18 +12064,17 @@
             }
         },
         "node_modules/regexpu-core": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
-            "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+            "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^10.2.0",
+                "regenerate-unicode-properties": "^10.2.2",
                 "regjsgen": "^0.8.0",
-                "regjsparser": "^0.12.0",
+                "regjsparser": "^0.13.0",
                 "unicode-match-property-ecmascript": "^2.0.0",
-                "unicode-match-property-value-ecmascript": "^2.1.0"
+                "unicode-match-property-value-ecmascript": "^2.2.1"
             },
             "engines": {
                 "node": ">=4"
@@ -12134,17 +12084,15 @@
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
             "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/regjsparser": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
-            "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
+            "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
-                "jsesc": "~3.0.2"
+                "jsesc": "~3.1.0"
             },
             "bin": {
                 "regjsparser": "bin/parser"
@@ -12252,17 +12200,20 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+            "version": "1.22.11",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.8.1",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
             "bin": {
                 "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -14250,7 +14201,6 @@
             "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
             "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
@@ -14260,7 +14210,6 @@
             "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
             "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "unicode-canonical-property-names-ecmascript": "^2.0.0",
                 "unicode-property-aliases-ecmascript": "^2.0.0"
@@ -14270,21 +14219,19 @@
             }
         },
         "node_modules/unicode-match-property-value-ecmascript": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
-            "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+            "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/unicode-property-aliases-ecmascript": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
-            "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+            "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
@@ -14409,9 +14356,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "funding": [
                 {
@@ -14427,7 +14374,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -14443,8 +14389,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/urix": {
             "version": "0.1.0",
@@ -14924,12 +14869,12 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -14943,9 +14888,9 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
-            "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
             "dev": true
         },
         "@babel/core": {
@@ -15001,34 +14946,34 @@
             }
         },
         "@babel/generator": {
-            "version": "7.27.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-            "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
             "dev": true,
             "requires": {
-                "@babel/parser": "^7.27.5",
-                "@babel/types": "^7.27.3",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
             }
         },
         "@babel/helper-annotate-as-pure": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz",
-            "integrity": "sha512-WnuuDILl9oOBbKnb4L+DyODx7iC47XfzmNCpTttFsSp6hTG7XZxu60+4IO+2/hPfcGOoKbFiwoI/+zwARbNQow==",
+            "version": "7.27.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.27.1"
+                "@babel/types": "^7.27.3"
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.27.2",
+                "@babel/compat-data": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
@@ -15059,17 +15004,17 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-            "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+            "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-member-expression-to-functions": "^7.28.5",
                 "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.28.6",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/traverse": "^7.27.1",
+                "@babel/traverse": "^7.28.6",
                 "semver": "^6.3.1"
             },
             "dependencies": {
@@ -15082,13 +15027,13 @@
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
-            "integrity": "sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+            "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "regexpu-core": "^6.2.0",
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "regexpu-core": "^6.3.1",
                 "semver": "^6.3.1"
             },
             "dependencies": {
@@ -15101,64 +15046,70 @@
             }
         },
         "@babel/helper-define-polyfill-provider": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
-            "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+            "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
             "dev": true,
             "requires": {
-                "@babel/helper-compilation-targets": "^7.22.6",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "debug": "^4.1.1",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "debug": "^4.4.3",
                 "lodash.debounce": "^4.0.8",
-                "resolve": "^1.14.2"
+                "resolve": "^1.22.11"
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "version": "4.4.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+                    "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.1.2"
+                        "ms": "^2.1.3"
                     }
                 },
                 "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
                     "dev": true
                 }
             }
         },
+        "@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "dev": true
+        },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-            "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+            "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.28.5",
+                "@babel/types": "^7.28.5"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-            "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.27.3"
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.28.6"
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -15171,9 +15122,9 @@
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
             "dev": true
         },
         "@babel/helper-remap-async-to-generator": {
@@ -15188,14 +15139,14 @@
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-            "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+            "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.27.1",
+                "@babel/helper-member-expression-to-functions": "^7.28.5",
                 "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/traverse": "^7.28.6"
             }
         },
         "@babel/helper-skip-transparent-expression-wrappers": {
@@ -15215,9 +15166,9 @@
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true
         },
         "@babel/helper-validator-option": {
@@ -15227,14 +15178,14 @@
             "dev": true
         },
         "@babel/helper-wrap-function": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
-            "integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+            "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.27.1",
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
             }
         },
         "@babel/helpers": {
@@ -15248,22 +15199,22 @@
             }
         },
         "@babel/parser": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.7.tgz",
-            "integrity": "sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.27.7"
+                "@babel/types": "^7.29.0"
             }
         },
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
-            "integrity": "sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+            "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/traverse": "^7.28.5"
             }
         },
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": {
@@ -15296,13 +15247,13 @@
             }
         },
         "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
-            "integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+            "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/traverse": "^7.28.6"
             }
         },
         "@babel/plugin-proposal-private-property-in-object": {
@@ -15313,21 +15264,21 @@
             "requires": {}
         },
         "@babel/plugin-syntax-import-assertions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
-            "integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+            "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-syntax-import-attributes": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-            "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+            "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-syntax-unicode-sets-regex": {
@@ -15350,24 +15301,24 @@
             }
         },
         "@babel/plugin-transform-async-generator-functions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
-            "integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+            "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-remap-async-to-generator": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/traverse": "^7.29.0"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
-            "integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+            "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-remap-async-to-generator": "^7.27.1"
             }
         },
@@ -15381,75 +15332,76 @@
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.1.tgz",
-            "integrity": "sha512-QEcFlMl9nGTgh1rn2nIeU5bkfb9BAjaQcWbiP4LvKxUot52ABcTkpcyJ7f2Q2U2RuQ84BNLgts3jRme2dTx6Fw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+            "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-class-properties": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
-            "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+            "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-class-static-block": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
-            "integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+            "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-classes": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
-            "integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+            "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-compilation-targets": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1",
-                "@babel/traverse": "^7.27.1",
-                "globals": "^11.1.0"
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-replace-supers": "^7.28.6",
+                "@babel/traverse": "^7.28.6"
             }
         },
         "@babel/plugin-transform-computed-properties": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
-            "integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+            "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/template": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/template": "^7.28.6"
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.1.tgz",
-            "integrity": "sha512-ttDCqhfvpE9emVkXbPD8vyxxh4TWYACVybGkDj+oReOGwnp066ITEivDlLwe0b1R0+evJ13IXQuLNB5w1fhC5Q==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+            "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/traverse": "^7.28.5"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
-            "integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+            "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
@@ -15462,13 +15414,13 @@
             }
         },
         "@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
-            "integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+            "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-dynamic-import": {
@@ -15480,13 +15432,23 @@
                 "@babel/helper-plugin-utils": "^7.27.1"
             }
         },
-        "@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
-            "integrity": "sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==",
+        "@babel/plugin-transform-explicit-resource-management": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+            "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/plugin-transform-destructuring": "^7.28.5"
+            }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+            "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-export-namespace-from": {
@@ -15520,12 +15482,12 @@
             }
         },
         "@babel/plugin-transform-json-strings": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
-            "integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+            "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-literals": {
@@ -15538,12 +15500,12 @@
             }
         },
         "@babel/plugin-transform-logical-assignment-operators": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
-            "integrity": "sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+            "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-member-expression-literals": {
@@ -15566,25 +15528,25 @@
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-            "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+            "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
-            "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+            "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.29.0"
             }
         },
         "@babel/plugin-transform-modules-umd": {
@@ -15598,13 +15560,13 @@
             }
         },
         "@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
-            "integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+            "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-new-target": {
@@ -15617,33 +15579,34 @@
             }
         },
         "@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
-            "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+            "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-numeric-separator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
-            "integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+            "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-object-rest-spread": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.2.tgz",
-            "integrity": "sha512-AIUHD7xJ1mCrj3uPozvtngY3s0xpv7Nu7DoUSnzNY6Xam1Cy4rUznR//pvMHOhQ4AvbCexhbqXCtpxGHOGOO6g==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+            "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
             "dev": true,
             "requires": {
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/plugin-transform-destructuring": "^7.27.1",
-                "@babel/plugin-transform-parameters": "^7.27.1"
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/plugin-transform-destructuring": "^7.28.5",
+                "@babel/plugin-transform-parameters": "^7.27.7",
+                "@babel/traverse": "^7.28.6"
             }
         },
         "@babel/plugin-transform-object-super": {
@@ -15657,52 +15620,52 @@
             }
         },
         "@babel/plugin-transform-optional-catch-binding": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
-            "integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+            "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-optional-chaining": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
-            "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+            "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
-            "integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
+            "version": "7.27.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+            "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.27.1"
             }
         },
         "@babel/plugin-transform-private-methods": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
-            "integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+            "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-private-property-in-object": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
-            "integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+            "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.27.1",
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-property-literals": {
@@ -15715,22 +15678,22 @@
             }
         },
         "@babel/plugin-transform-regenerator": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.1.tgz",
-            "integrity": "sha512-B19lbbL7PMrKr52BNPjCqg1IyNUIjTcxKj8uX9zHO+PmWN93s19NDr/f69mIkEp2x9nmDJ08a7lgHaTTzvW7mw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+            "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-regexp-modifiers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
-            "integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+            "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-reserved-words": {
@@ -15752,12 +15715,12 @@
             }
         },
         "@babel/plugin-transform-spread": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
-            "integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+            "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
             }
         },
@@ -15798,13 +15761,13 @@
             }
         },
         "@babel/plugin-transform-unicode-property-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
-            "integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+            "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
@@ -15818,89 +15781,90 @@
             }
         },
         "@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
-            "integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+            "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
             }
         },
         "@babel/preset-env": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
-            "integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+            "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.27.2",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/compat-data": "^7.29.0",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
+                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
                 "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
                 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
                 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
+                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
                 "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-                "@babel/plugin-syntax-import-assertions": "^7.27.1",
-                "@babel/plugin-syntax-import-attributes": "^7.27.1",
+                "@babel/plugin-syntax-import-assertions": "^7.28.6",
+                "@babel/plugin-syntax-import-attributes": "^7.28.6",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.27.1",
-                "@babel/plugin-transform-async-generator-functions": "^7.27.1",
-                "@babel/plugin-transform-async-to-generator": "^7.27.1",
+                "@babel/plugin-transform-async-generator-functions": "^7.29.0",
+                "@babel/plugin-transform-async-to-generator": "^7.28.6",
                 "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-                "@babel/plugin-transform-block-scoping": "^7.27.1",
-                "@babel/plugin-transform-class-properties": "^7.27.1",
-                "@babel/plugin-transform-class-static-block": "^7.27.1",
-                "@babel/plugin-transform-classes": "^7.27.1",
-                "@babel/plugin-transform-computed-properties": "^7.27.1",
-                "@babel/plugin-transform-destructuring": "^7.27.1",
-                "@babel/plugin-transform-dotall-regex": "^7.27.1",
+                "@babel/plugin-transform-block-scoping": "^7.28.6",
+                "@babel/plugin-transform-class-properties": "^7.28.6",
+                "@babel/plugin-transform-class-static-block": "^7.28.6",
+                "@babel/plugin-transform-classes": "^7.28.6",
+                "@babel/plugin-transform-computed-properties": "^7.28.6",
+                "@babel/plugin-transform-destructuring": "^7.28.5",
+                "@babel/plugin-transform-dotall-regex": "^7.28.6",
                 "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
                 "@babel/plugin-transform-dynamic-import": "^7.27.1",
-                "@babel/plugin-transform-exponentiation-operator": "^7.27.1",
+                "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+                "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
                 "@babel/plugin-transform-export-namespace-from": "^7.27.1",
                 "@babel/plugin-transform-for-of": "^7.27.1",
                 "@babel/plugin-transform-function-name": "^7.27.1",
-                "@babel/plugin-transform-json-strings": "^7.27.1",
+                "@babel/plugin-transform-json-strings": "^7.28.6",
                 "@babel/plugin-transform-literals": "^7.27.1",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
                 "@babel/plugin-transform-member-expression-literals": "^7.27.1",
                 "@babel/plugin-transform-modules-amd": "^7.27.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-                "@babel/plugin-transform-modules-systemjs": "^7.27.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.28.6",
+                "@babel/plugin-transform-modules-systemjs": "^7.29.0",
                 "@babel/plugin-transform-modules-umd": "^7.27.1",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
                 "@babel/plugin-transform-new-target": "^7.27.1",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-                "@babel/plugin-transform-numeric-separator": "^7.27.1",
-                "@babel/plugin-transform-object-rest-spread": "^7.27.2",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+                "@babel/plugin-transform-numeric-separator": "^7.28.6",
+                "@babel/plugin-transform-object-rest-spread": "^7.28.6",
                 "@babel/plugin-transform-object-super": "^7.27.1",
-                "@babel/plugin-transform-optional-catch-binding": "^7.27.1",
-                "@babel/plugin-transform-optional-chaining": "^7.27.1",
-                "@babel/plugin-transform-parameters": "^7.27.1",
-                "@babel/plugin-transform-private-methods": "^7.27.1",
-                "@babel/plugin-transform-private-property-in-object": "^7.27.1",
+                "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+                "@babel/plugin-transform-optional-chaining": "^7.28.6",
+                "@babel/plugin-transform-parameters": "^7.27.7",
+                "@babel/plugin-transform-private-methods": "^7.28.6",
+                "@babel/plugin-transform-private-property-in-object": "^7.28.6",
                 "@babel/plugin-transform-property-literals": "^7.27.1",
-                "@babel/plugin-transform-regenerator": "^7.27.1",
-                "@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+                "@babel/plugin-transform-regenerator": "^7.29.0",
+                "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
                 "@babel/plugin-transform-reserved-words": "^7.27.1",
                 "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-                "@babel/plugin-transform-spread": "^7.27.1",
+                "@babel/plugin-transform-spread": "^7.28.6",
                 "@babel/plugin-transform-sticky-regex": "^7.27.1",
                 "@babel/plugin-transform-template-literals": "^7.27.1",
                 "@babel/plugin-transform-typeof-symbol": "^7.27.1",
                 "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-                "@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+                "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
                 "@babel/plugin-transform-unicode-regex": "^7.27.1",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
-                "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.11.0",
-                "babel-plugin-polyfill-regenerator": "^0.6.1",
-                "core-js-compat": "^3.40.0",
+                "babel-plugin-polyfill-corejs2": "^0.4.15",
+                "babel-plugin-polyfill-corejs3": "^0.14.0",
+                "babel-plugin-polyfill-regenerator": "^0.6.6",
+                "core-js-compat": "^3.48.0",
                 "semver": "^6.3.1"
             },
             "dependencies": {
@@ -15924,29 +15888,29 @@
             }
         },
         "@babel/template": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/parser": "^7.27.2",
-                "@babel/types": "^7.27.1"
+                "@babel/code-frame": "^7.28.6",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6"
             }
         },
         "@babel/traverse": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.7.tgz",
-            "integrity": "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.27.5",
-                "@babel/parser": "^7.27.7",
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.7",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0",
+                "debug": "^4.3.1"
             },
             "dependencies": {
                 "debug": {
@@ -15967,13 +15931,13 @@
             }
         },
         "@babel/types": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.7.tgz",
-            "integrity": "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "dev": true,
             "requires": {
                 "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1"
+                "@babel/helper-validator-identifier": "^7.28.5"
             }
         },
         "@gulp-sourcemaps/identity-map": {
@@ -16045,13 +16009,12 @@
             }
         },
         "@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
             "requires": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
@@ -16059,12 +16022,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
             "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-            "dev": true
-        },
-        "@jridgewell/set-array": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true
         },
         "@jridgewell/source-map": {
@@ -16078,15 +16035,15 @@
             }
         },
         "@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -16665,13 +16622,13 @@
             }
         },
         "babel-plugin-polyfill-corejs2": {
-            "version": "0.4.10",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.10.tgz",
-            "integrity": "sha512-rpIuu//y5OX6jVU+a5BCn1R5RSZYWAl2Nar76iwaOdycqb6JPxediskWFMMl7stfwNJR4b7eiQvh5fB5TEQJTQ==",
+            "version": "0.4.17",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+            "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.22.6",
-                "@babel/helper-define-polyfill-provider": "^0.6.1",
+                "@babel/compat-data": "^7.28.6",
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
                 "semver": "^6.3.1"
             },
             "dependencies": {
@@ -16684,22 +16641,22 @@
             }
         },
         "babel-plugin-polyfill-corejs3": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
-            "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+            "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
             "dev": true,
             "requires": {
-                "@babel/helper-define-polyfill-provider": "^0.6.3",
-                "core-js-compat": "^3.40.0"
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
+                "core-js-compat": "^3.48.0"
             }
         },
         "babel-plugin-polyfill-regenerator": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.1.tgz",
-            "integrity": "sha512-JfTApdE++cgcTWjsiCQlLyFBMbTUft9ja17saCc93lgV33h4tuCVj7tlvu//qpLwaG+3yEz7/KhahGrUMkVq9g==",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+            "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
             "dev": true,
             "requires": {
-                "@babel/helper-define-polyfill-provider": "^0.6.1"
+                "@babel/helper-define-polyfill-provider": "^0.6.8"
             }
         },
         "babelify": {
@@ -16797,6 +16754,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "dev": true
+        },
+        "baseline-browser-mapping": {
+            "version": "2.10.12",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+            "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
             "dev": true
         },
         "batch": {
@@ -17379,15 +17342,16 @@
             }
         },
         "browserslist": {
-            "version": "4.24.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-            "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001716",
-                "electron-to-chromium": "^1.5.149",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.3"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             }
         },
         "bs-recipes": {
@@ -17611,9 +17575,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001717",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-            "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+            "version": "1.0.30001782",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+            "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
             "dev": true
         },
         "caw": {
@@ -17966,12 +17930,12 @@
             }
         },
         "core-js-compat": {
-            "version": "3.40.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
-            "integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+            "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.3"
+                "browserslist": "^4.28.1"
             }
         },
         "core-util-is": {
@@ -18757,9 +18721,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.5.150",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz",
-            "integrity": "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==",
+            "version": "1.5.329",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
+            "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
             "dev": true
         },
         "elliptic": {
@@ -20193,12 +20157,6 @@
                 "which": "^1.2.14"
             }
         },
-        "globals": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true
-        },
         "globby": {
             "version": "14.0.1",
             "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
@@ -20815,15 +20773,6 @@
                 "glogg": "^1.0.0"
             }
         },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1"
-            }
-        },
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -21432,12 +21381,12 @@
             "dev": true
         },
         "is-core-module": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
             "dev": true,
             "requires": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.2"
             }
         },
         "is-data-descriptor": {
@@ -21732,9 +21681,9 @@
             "dev": true
         },
         "jsesc": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true
         },
         "json-buffer": {
@@ -22474,9 +22423,9 @@
             "optional": true
         },
         "node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "version": "2.0.36",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
             "dev": true
         },
         "normalize-package-data": {
@@ -23894,9 +23843,9 @@
             "dev": true
         },
         "regenerate-unicode-properties": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
-            "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+            "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.2"
@@ -23913,17 +23862,17 @@
             }
         },
         "regexpu-core": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
-            "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+            "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^10.2.0",
+                "regenerate-unicode-properties": "^10.2.2",
                 "regjsgen": "^0.8.0",
-                "regjsparser": "^0.12.0",
+                "regjsparser": "^0.13.0",
                 "unicode-match-property-ecmascript": "^2.0.0",
-                "unicode-match-property-value-ecmascript": "^2.1.0"
+                "unicode-match-property-value-ecmascript": "^2.2.1"
             }
         },
         "regjsgen": {
@@ -23933,12 +23882,12 @@
             "dev": true
         },
         "regjsparser": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
-            "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
+            "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
             "dev": true,
             "requires": {
-                "jsesc": "~3.0.2"
+                "jsesc": "~3.1.0"
             }
         },
         "remove-bom-buffer": {
@@ -24016,12 +23965,12 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+            "version": "1.22.11",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
             "dev": true,
             "requires": {
-                "is-core-module": "^2.8.1",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             }
@@ -25593,15 +25542,15 @@
             }
         },
         "unicode-match-property-value-ecmascript": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
-            "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+            "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
             "dev": true
         },
         "unicode-property-aliases-ecmascript": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
-            "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+            "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
             "dev": true
         },
         "unicorn-magic": {
@@ -25697,9 +25646,9 @@
             "dev": true
         },
         "update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "requires": {
                 "escalade": "^3.2.0",

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -8,7 +8,7 @@
             "name": "csfieldguide",
             "version": "1.0.0",
             "devDependencies": {
-                "@babel/core": "^7.27.7",
+                "@babel/core": "^7.29.0",
                 "@babel/preset-env": "^7.29.2",
                 "ansi-colors": "4.1.3",
                 "autoprefixer": "10.4.27",
@@ -49,19 +49,6 @@
                 "node": ">=14.16"
             }
         },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -93,21 +80,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
-            "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.27.5",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.27.3",
-                "@babel/helpers": "^7.27.6",
-                "@babel/parser": "^7.27.7",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.27.7",
-                "@babel/types": "^7.27.7",
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helpers": "^7.28.6",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -489,13 +476,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-            "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.6"
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1812,6 +1799,16 @@
             "dev": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
@@ -14855,16 +14852,6 @@
         }
     },
     "dependencies": {
-        "@ampproject/remapping": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-            "dev": true,
-            "requires": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
-            }
-        },
         "@babel/code-frame": {
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -14891,21 +14878,21 @@
             "dev": true
         },
         "@babel/core": {
-            "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
-            "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "requires": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.27.5",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.27.3",
-                "@babel/helpers": "^7.27.6",
-                "@babel/parser": "^7.27.7",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.27.7",
-                "@babel/types": "^7.27.7",
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helpers": "^7.28.6",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -15186,13 +15173,13 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-            "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.27.6"
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0"
             }
         },
         "@babel/parser": {
@@ -16055,6 +16042,16 @@
             "dev": true,
             "requires": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -9859,9 +9859,9 @@
             "dev": true
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -9985,21 +9985,21 @@
             }
         },
         "node_modules/multimatch/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
         "node_modules/multimatch/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -22284,9 +22284,9 @@
             "dev": true
         },
         "minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
@@ -22383,21 +22383,21 @@
             },
             "dependencies": {
                 "brace-expansion": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+                    "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
                     }
                 },
                 "minimatch": {
-                    "version": "9.0.3",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-                    "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+                    "version": "9.0.9",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+                    "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^2.0.1"
+                        "brace-expansion": "^2.0.2"
                     }
                 }
             }

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -11,7 +11,7 @@
                 "@babel/core": "^7.27.7",
                 "@babel/preset-env": "^7.27.2",
                 "ansi-colors": "4.1.3",
-                "autoprefixer": "10.4.21",
+                "autoprefixer": "10.4.27",
                 "babelify": "^10.0.0",
                 "bootstrap": "4.6.2",
                 "browser-sync": "3.0.4",
@@ -2671,9 +2671,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.21",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-            "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+            "version": "10.4.27",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+            "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
             "dev": true,
             "funding": [
                 {
@@ -2689,12 +2689,10 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.4",
-                "caniuse-lite": "^1.0.30001702",
-                "fraction.js": "^4.3.7",
-                "normalize-range": "^0.1.2",
+                "browserslist": "^4.28.1",
+                "caniuse-lite": "^1.0.30001774",
+                "fraction.js": "^5.3.4",
                 "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -2913,6 +2911,18 @@
             "dev": true,
             "engines": {
                 "node": "^4.5.0 || >= 5.9"
+            }
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.12",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+            "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+            "dev": true,
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/batch": {
@@ -3595,9 +3605,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.24.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-            "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
             "funding": [
                 {
@@ -3613,12 +3623,12 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001716",
-                "electron-to-chromium": "^1.5.149",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.3"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -3897,9 +3907,9 @@
             "license": "MIT"
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001717",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-            "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+            "version": "1.0.30001782",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+            "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
             "dev": true,
             "funding": [
                 {
@@ -3914,8 +3924,7 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ],
-            "license": "CC-BY-4.0"
+            ]
         },
         "node_modules/caw": {
             "version": "2.0.1",
@@ -5355,11 +5364,10 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.150",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz",
-            "integrity": "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==",
-            "dev": true,
-            "license": "ISC"
+            "version": "1.5.329",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
+            "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
+            "dev": true
         },
         "node_modules/elliptic": {
             "version": "6.6.1",
@@ -6465,15 +6473,15 @@
             "dev": true
         },
         "node_modules/fraction.js": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+            "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
             "dev": true,
             "engines": {
                 "node": "*"
             },
             "funding": {
-                "type": "patreon",
+                "type": "github",
                 "url": "https://github.com/sponsors/rawify"
             }
         },
@@ -10104,11 +10112,10 @@
             "optional": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "2.0.36",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+            "dev": true
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -10126,15 +10133,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/normalize-range": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-            "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -14409,9 +14407,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "funding": [
                 {
@@ -14427,7 +14425,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -14443,8 +14440,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/urix": {
             "version": "0.1.0",
@@ -16634,15 +16630,14 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "10.4.21",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-            "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+            "version": "10.4.27",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+            "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.4",
-                "caniuse-lite": "^1.0.30001702",
-                "fraction.js": "^4.3.7",
-                "normalize-range": "^0.1.2",
+                "browserslist": "^4.28.1",
+                "caniuse-lite": "^1.0.30001774",
+                "fraction.js": "^5.3.4",
                 "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -16797,6 +16792,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "dev": true
+        },
+        "baseline-browser-mapping": {
+            "version": "2.10.12",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+            "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
             "dev": true
         },
         "batch": {
@@ -17379,15 +17380,16 @@
             }
         },
         "browserslist": {
-            "version": "4.24.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-            "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001716",
-                "electron-to-chromium": "^1.5.149",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.3"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             }
         },
         "bs-recipes": {
@@ -17611,9 +17613,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001717",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-            "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+            "version": "1.0.30001782",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+            "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
             "dev": true
         },
         "caw": {
@@ -18757,9 +18759,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.5.150",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz",
-            "integrity": "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==",
+            "version": "1.5.329",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
+            "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
             "dev": true
         },
         "elliptic": {
@@ -19647,9 +19649,9 @@
             "dev": true
         },
         "fraction.js": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+            "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
             "dev": true
         },
         "fragment-cache": {
@@ -22474,9 +22476,9 @@
             "optional": true
         },
         "node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "version": "2.0.36",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
             "dev": true
         },
         "normalize-package-data": {
@@ -22495,12 +22497,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
-        },
-        "normalize-range": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-            "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
             "dev": true
         },
         "now-and-later": {
@@ -25697,9 +25693,9 @@
             "dev": true
         },
         "update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "requires": {
                 "escalade": "^3.2.0",

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -41,7 +41,7 @@
                 "popper.js": "1.16.1",
                 "postcss": "8.5.6",
                 "postcss-flexbugs-fixes": "5.0.2",
-                "sass": "1.89.2",
+                "sass": "1.98.0",
                 "vinyl-buffer": "1.0.1",
                 "yargs": "17.7.2"
             },
@@ -12439,14 +12439,13 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.89.2",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
-            "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
+            "version": "1.98.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+            "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chokidar": "^4.0.0",
-                "immutable": "^5.0.2",
+                "immutable": "^5.1.5",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
             "bin": {
@@ -24151,14 +24150,14 @@
             "dev": true
         },
         "sass": {
-            "version": "1.89.2",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
-            "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
+            "version": "1.98.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+            "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
             "dev": true,
             "requires": {
                 "@parcel/watcher": "^2.4.1",
                 "chokidar": "^4.0.0",
-                "immutable": "^5.0.2",
+                "immutable": "^5.1.5",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
             "dependencies": {

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -17,7 +17,7 @@
                 "browser-sync": "3.0.4",
                 "browserify": "17.0.1",
                 "codemirror": "5.65.6",
-                "cssnano": "7.0.7",
+                "cssnano": "7.1.4",
                 "details-element-polyfill": "2.4.0",
                 "fancy-log": "2.0.0",
                 "gulp": "4.0.2",
@@ -1680,6 +1680,12 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@colordx/core": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.0.0.tgz",
+            "integrity": "sha512-twwxohWH8hWWh5ZJ5z6ZNn/JyMrq08K+NzxXKVGTpH+XmMPDAYYzqvszc3OPhYhqqxmfnbCSa/YHcS7pCnChmw==",
+            "dev": true
+        },
         "node_modules/@gulp-sourcemaps/identity-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
@@ -2915,6 +2921,18 @@
                 "node": "^4.5.0 || >= 5.9"
             }
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.12",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+            "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+            "dev": true,
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -3595,9 +3613,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.24.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-            "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
             "funding": [
                 {
@@ -3613,12 +3631,12 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001716",
-                "electron-to-chromium": "^1.5.149",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.3"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -3881,7 +3899,6 @@
             "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
             "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "browserslist": "^4.0.0",
                 "caniuse-lite": "^1.0.0",
@@ -3893,13 +3910,12 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001717",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-            "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+            "version": "1.0.30001782",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+            "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
             "dev": true,
             "funding": [
                 {
@@ -3914,8 +3930,7 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ],
-            "license": "CC-BY-4.0"
+            ]
         },
         "node_modules/caw": {
             "version": "2.0.1",
@@ -4156,13 +4171,6 @@
             "bin": {
                 "color-support": "bin.js"
             }
-        },
-        "node_modules/colord": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-            "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/combine-source-map": {
             "version": "0.8.0",
@@ -4479,11 +4487,10 @@
             }
         },
         "node_modules/css-declaration-sorter": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
-            "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
+            "integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": "^14 || ^16 || >=18"
             },
@@ -4575,7 +4582,6 @@
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "cssesc": "bin/cssesc"
             },
@@ -4584,13 +4590,12 @@
             }
         },
         "node_modules/cssnano": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.7.tgz",
-            "integrity": "sha512-evKu7yiDIF7oS+EIpwFlMF730ijRyLFaM2o5cTxRGJR9OKHKkc+qP443ZEVR9kZG0syaAJJCPJyfv5pbrxlSng==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.4.tgz",
+            "integrity": "sha512-T9PNS7y+5Nc9Qmu9mRONqfxG1RVY7Vuvky0XN6MZ+9hqplesTEwnj9r0ROtVuSwUVfaDhVlavuzWIVLUgm4hkQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "cssnano-preset-default": "^7.0.7",
+                "cssnano-preset-default": "^7.0.12",
                 "lilconfig": "^3.1.3"
             },
             "engines": {
@@ -4605,42 +4610,41 @@
             }
         },
         "node_modules/cssnano-preset-default": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.7.tgz",
-            "integrity": "sha512-jW6CG/7PNB6MufOrlovs1TvBTEVmhY45yz+bd0h6nw3h6d+1e+/TX+0fflZ+LzvZombbT5f+KC063w9VoHeHow==",
+            "version": "7.0.12",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.12.tgz",
+            "integrity": "sha512-B3Eoouzw/sl2zANI0AL9KbacummJTCww+fkHaDBMZad/xuVx8bUduPLly6hKVQAlrmvYkS1jB1CVQEKm3gn0AA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "css-declaration-sorter": "^7.2.0",
                 "cssnano-utils": "^5.0.1",
                 "postcss-calc": "^10.1.1",
-                "postcss-colormin": "^7.0.3",
-                "postcss-convert-values": "^7.0.5",
-                "postcss-discard-comments": "^7.0.4",
+                "postcss-colormin": "^7.0.7",
+                "postcss-convert-values": "^7.0.9",
+                "postcss-discard-comments": "^7.0.6",
                 "postcss-discard-duplicates": "^7.0.2",
                 "postcss-discard-empty": "^7.0.1",
                 "postcss-discard-overridden": "^7.0.1",
                 "postcss-merge-longhand": "^7.0.5",
-                "postcss-merge-rules": "^7.0.5",
+                "postcss-merge-rules": "^7.0.8",
                 "postcss-minify-font-values": "^7.0.1",
-                "postcss-minify-gradients": "^7.0.1",
-                "postcss-minify-params": "^7.0.3",
-                "postcss-minify-selectors": "^7.0.5",
+                "postcss-minify-gradients": "^7.0.2",
+                "postcss-minify-params": "^7.0.6",
+                "postcss-minify-selectors": "^7.0.6",
                 "postcss-normalize-charset": "^7.0.1",
                 "postcss-normalize-display-values": "^7.0.1",
                 "postcss-normalize-positions": "^7.0.1",
                 "postcss-normalize-repeat-style": "^7.0.1",
                 "postcss-normalize-string": "^7.0.1",
                 "postcss-normalize-timing-functions": "^7.0.1",
-                "postcss-normalize-unicode": "^7.0.3",
+                "postcss-normalize-unicode": "^7.0.6",
                 "postcss-normalize-url": "^7.0.1",
                 "postcss-normalize-whitespace": "^7.0.1",
                 "postcss-ordered-values": "^7.0.2",
-                "postcss-reduce-initial": "^7.0.3",
+                "postcss-reduce-initial": "^7.0.6",
                 "postcss-reduce-transforms": "^7.0.1",
-                "postcss-svgo": "^7.0.2",
-                "postcss-unique-selectors": "^7.0.4"
+                "postcss-svgo": "^7.1.1",
+                "postcss-unique-selectors": "^7.0.5"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4654,7 +4658,6 @@
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.1.tgz",
             "integrity": "sha512-ZIP71eQgG9JwjVZsTPSqhc6GHgEr53uJ7tK5///VfyWj6Xp2DBmixWHqJgPno+PqATzn48pL42ww9x5SSGmhZg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
@@ -5355,11 +5358,10 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.150",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz",
-            "integrity": "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==",
-            "dev": true,
-            "license": "ISC"
+            "version": "1.5.329",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
+            "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
+            "dev": true
         },
         "node_modules/elliptic": {
             "version": "6.6.1",
@@ -9444,8 +9446,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
             "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lowercase-keys": {
             "version": "1.0.1",
@@ -10104,11 +10105,10 @@
             "optional": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "2.0.36",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+            "dev": true
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -11019,7 +11019,6 @@
             "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
             "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-selector-parser": "^7.0.0",
                 "postcss-value-parser": "^4.2.0"
@@ -11032,15 +11031,14 @@
             }
         },
         "node_modules/postcss-colormin": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.3.tgz",
-            "integrity": "sha512-xZxQcSyIVZbSsl1vjoqZAcMYYdnJsIyG8OvqShuuqf12S88qQboxxEy0ohNCOLwVPXTU+hFHvJPACRL2B5ohTA==",
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.7.tgz",
+            "integrity": "sha512-sBQ628lSj3VQpDquQel8Pen5mmjFPsO4pH9lDLaHB1AVkMRHtkl0pRB5DCWznc9upWsxint/kV+AveSj7W1tew==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.5",
+                "@colordx/core": "^5.0.0",
+                "browserslist": "^4.28.1",
                 "caniuse-api": "^3.0.0",
-                "colord": "^2.9.3",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -11051,13 +11049,12 @@
             }
         },
         "node_modules/postcss-convert-values": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.5.tgz",
-            "integrity": "sha512-0VFhH8nElpIs3uXKnVtotDJJNX0OGYSZmdt4XfSfvOMrFw1jKfpwpZxfC4iN73CTM/MWakDEmsHQXkISYj4BXw==",
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.9.tgz",
+            "integrity": "sha512-l6uATQATZaCa0bckHV+r6dLXfWtUBKXxO3jK+AtxxJJtgMPD+VhhPCCx51I4/5w8U5uHV67g3w7PXj+V3wlMlg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -11068,13 +11065,12 @@
             }
         },
         "node_modules/postcss-discard-comments": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.4.tgz",
-            "integrity": "sha512-6tCUoql/ipWwKtVP/xYiFf1U9QgJ0PUvxN7pTcsQ8Ns3Fnwq1pU5D5s1MhT/XySeLq6GXNvn37U46Ded0TckWg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.6.tgz",
+            "integrity": "sha512-Sq+Fzj1Eg5/CPf1ERb0wS1Im5cvE2gDXCE+si4HCn1sf+jpQZxDI4DXEp8t77B/ImzDceWE2ebJQFXdqZ6GRJw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "postcss-selector-parser": "^7.1.0"
+                "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -11088,7 +11084,6 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.2.tgz",
             "integrity": "sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
@@ -11101,7 +11096,6 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.1.tgz",
             "integrity": "sha512-cFrJKZvcg/uxB6Ijr4l6qmn3pXQBna9zyrPC+sK0zjbkDUZew+6xDltSF7OeB7rAtzaaMVYSdbod+sZOCWnMOg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
@@ -11114,7 +11108,6 @@
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.1.tgz",
             "integrity": "sha512-7c3MMjjSZ/qYrx3uc1940GSOzN1Iqjtlqe8uoSg+qdVPYyRb0TILSqqmtlSFuE4mTDECwsm397Ya7iXGzfF7lg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
@@ -11171,7 +11164,6 @@
             "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.5.tgz",
             "integrity": "sha512-Kpu5v4Ys6QI59FxmxtNB/iHUVDn9Y9sYw66D6+SZoIk4QTz1prC4aYkhIESu+ieG1iylod1f8MILMs1Em3mmIw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
                 "stylehacks": "^7.0.5"
@@ -11184,16 +11176,15 @@
             }
         },
         "node_modules/postcss-merge-rules": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.5.tgz",
-            "integrity": "sha512-ZonhuSwEaWA3+xYbOdJoEReKIBs5eDiBVLAGpYZpNFPzXZcEE5VKR7/qBEQvTZpiwjqhhqEQ+ax5O3VShBj9Wg==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.8.tgz",
+            "integrity": "sha512-BOR1iAM8jnr7zoQSlpeBmCsWV5Uudi/+5j7k05D0O/WP3+OFMPD86c1j/20xiuRtyt45bhxw/7hnhZNhW2mNFA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "caniuse-api": "^3.0.0",
                 "cssnano-utils": "^5.0.1",
-                "postcss-selector-parser": "^7.1.0"
+                "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -11207,7 +11198,6 @@
             "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.1.tgz",
             "integrity": "sha512-2m1uiuJeTplll+tq4ENOQSzB8LRnSUChBv7oSyFLsJRtUgAAJGP6LLz0/8lkinTgxrmJSPOEhgY1bMXOQ4ZXhQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11219,13 +11209,12 @@
             }
         },
         "node_modules/postcss-minify-gradients": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.1.tgz",
-            "integrity": "sha512-X9JjaysZJwlqNkJbUDgOclyG3jZEpAMOfof6PUZjPnPrePnPG62pS17CjdM32uT1Uq1jFvNSff9l7kNbmMSL2A==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.2.tgz",
+            "integrity": "sha512-fVY3AB8Um7SJR5usHqTY2Ngf9qh8IRN+FFzrBP0ONJy6yYXsP7xyjK2BvSAIrpgs1cST+H91V0TXi3diHLYJtw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "colord": "^2.9.3",
+                "@colordx/core": "^5.0.0",
                 "cssnano-utils": "^5.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11237,13 +11226,12 @@
             }
         },
         "node_modules/postcss-minify-params": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.3.tgz",
-            "integrity": "sha512-vUKV2+f5mtjewYieanLX0xemxIp1t0W0H/D11u+kQV/MWdygOO7xPMkbK+r9P6Lhms8MgzKARF/g5OPXhb8tgg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.6.tgz",
+            "integrity": "sha512-YOn02gC68JijlaXVuKvFSCvQOhTpblkcfDre2hb/Aaa58r2BIaK4AtE/cyZf2wV7YKAG+UlP9DT+By0ry1E4VQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "cssnano-utils": "^5.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11255,14 +11243,13 @@
             }
         },
         "node_modules/postcss-minify-selectors": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.5.tgz",
-            "integrity": "sha512-x2/IvofHcdIrAm9Q+p06ZD1h6FPcQ32WtCRVodJLDR+WMn8EVHI1kvLxZuGKz/9EY5nAmI6lIQIrpo4tBy5+ug==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.6.tgz",
+            "integrity": "sha512-lIbC0jy3AAwDxEgciZlBullDiMBeBCT+fz5G8RcA9MWqh/hfUkpOI3vNDUNEZHgokaoiv0juB9Y8fGcON7rU/A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
-                "postcss-selector-parser": "^7.1.0"
+                "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -11276,7 +11263,6 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.1.tgz",
             "integrity": "sha512-sn413ofhSQHlZFae//m9FTOfkmiZ+YQXsbosqOWRiVQncU2BA3daX3n0VF3cG6rGLSFVc5Di/yns0dFfh8NFgQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
             },
@@ -11289,7 +11275,6 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.1.tgz",
             "integrity": "sha512-E5nnB26XjSYz/mGITm6JgiDpAbVuAkzXwLzRZtts19jHDUBFxZ0BkXAehy0uimrOjYJbocby4FVswA/5noOxrQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11305,7 +11290,6 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.1.tgz",
             "integrity": "sha512-pB/SzrIP2l50ZIYu+yQZyMNmnAcwyYb9R1fVWPRxm4zcUFCY2ign7rcntGFuMXDdd9L2pPNUgoODDk91PzRZuQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11321,7 +11305,6 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.1.tgz",
             "integrity": "sha512-NsSQJ8zj8TIDiF0ig44Byo3Jk9e4gNt9x2VIlJudnQQ5DhWAHJPF4Tr1ITwyHio2BUi/I6Iv0HRO7beHYOloYQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11337,7 +11320,6 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.1.tgz",
             "integrity": "sha512-QByrI7hAhsoze992kpbMlJSbZ8FuCEc1OT9EFbZ6HldXNpsdpZr+YXC5di3UEv0+jeZlHbZcoCADgb7a+lPmmQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11353,7 +11335,6 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.1.tgz",
             "integrity": "sha512-bHifyuuSNdKKsnNJ0s8fmfLMlvsQwYVxIoUBnowIVl2ZAdrkYQNGVB4RxjfpvkMjipqvbz0u7feBZybkl/6NJg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11365,13 +11346,12 @@
             }
         },
         "node_modules/postcss-normalize-unicode": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.3.tgz",
-            "integrity": "sha512-EcoA29LvG3F+EpOh03iqu+tJY3uYYKzArqKJHxDhUYLa2u58aqGq16K6/AOsXD9yqLN8O6y9mmePKN5cx6krOw==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.6.tgz",
+            "integrity": "sha512-z6bwTV84YW6ZvvNoaNLuzRW4/uWxDKYI1iIDrzk6D2YTL7hICApy+Q1LP6vBEsljX8FM7YSuV9qI79XESd4ddQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -11386,7 +11366,6 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.1.tgz",
             "integrity": "sha512-sUcD2cWtyK1AOL/82Fwy1aIVm/wwj5SdZkgZ3QiUzSzQQofrbq15jWJ3BA7Z+yVRwamCjJgZJN0I9IS7c6tgeQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11402,7 +11381,6 @@
             "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.1.tgz",
             "integrity": "sha512-vsbgFHMFQrJBJKrUFJNZ2pgBeBkC2IvvoHjz1to0/0Xk7sII24T0qFOiJzG6Fu3zJoq/0yI4rKWi7WhApW+EFA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11418,7 +11396,6 @@
             "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.2.tgz",
             "integrity": "sha512-AMJjt1ECBffF7CEON/Y0rekRLS6KsePU6PRP08UqYW4UGFRnTXNrByUzYK1h8AC7UWTZdQ9O3Oq9kFIhm0SFEw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cssnano-utils": "^5.0.1",
                 "postcss-value-parser": "^4.2.0"
@@ -11431,13 +11408,12 @@
             }
         },
         "node_modules/postcss-reduce-initial": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.3.tgz",
-            "integrity": "sha512-RFvkZaqiWtGMlVjlUHpaxGqEL27lgt+Q2Ixjf83CRAzqdo+TsDyGPtJUbPx2MuYIJ+sCQc2TrOvRnhcXQfgIVA==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.6.tgz",
+            "integrity": "sha512-G6ZyK68AmrPdMB6wyeA37ejnnRG2S8xinJrZJnOv+IaRKf6koPAVbQsiC7MfkmXaGmF1UO+QCijb27wfpxuRNg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "caniuse-api": "^3.0.0"
             },
             "engines": {
@@ -11452,7 +11428,6 @@
             "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.1.tgz",
             "integrity": "sha512-MhyEbfrm+Mlp/36hvZ9mT9DaO7dbncU0CvWI8V93LRkY6IYlu38OPg3FObnuKTUxJ4qA8HpurdQOo5CyqqO76g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
             },
@@ -11464,11 +11439,10 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -11478,14 +11452,13 @@
             }
         },
         "node_modules/postcss-svgo": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.0.2.tgz",
-            "integrity": "sha512-5Dzy66JlnRM6pkdOTF8+cGsB1fnERTE8Nc+Eed++fOWo1hdsBptCsbG8UuJkgtZt75bRtMJIrPeZmtfANixdFA==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.1.tgz",
+            "integrity": "sha512-zU9H9oEDrUFKa0JB7w+IYL7Qs9ey1mZyjhbf0KLxwJDdDRtoPvCmaEfknzqfHj44QS9VD6c5sJnBAVYTLRg/Sg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "svgo": "^3.3.2"
+                "svgo": "^4.0.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >= 18"
@@ -11495,21 +11468,19 @@
             }
         },
         "node_modules/postcss-svgo/node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">= 10"
+                "node": ">=16"
             }
         },
         "node_modules/postcss-svgo/node_modules/css-select": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-what": "^6.1.0",
@@ -11522,14 +11493,13 @@
             }
         },
         "node_modules/postcss-svgo/node_modules/css-tree": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "mdn-data": "2.0.30",
-                "source-map-js": "^1.0.1"
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -11540,7 +11510,6 @@
             "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
             "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "css-tree": "~2.2.0"
             },
@@ -11554,7 +11523,6 @@
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
             "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "mdn-data": "2.0.28",
                 "source-map-js": "^1.0.1"
@@ -11568,15 +11536,13 @@
             "version": "2.0.28",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
             "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-            "dev": true,
-            "license": "CC0-1.0"
+            "dev": true
         },
         "node_modules/postcss-svgo/node_modules/dom-serializer": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
             "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.2",
@@ -11591,7 +11557,6 @@
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
             "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "domelementtype": "^2.3.0"
             },
@@ -11607,7 +11572,6 @@
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
             "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
@@ -11622,7 +11586,6 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
             },
@@ -11631,38 +11594,36 @@
             }
         },
         "node_modules/postcss-svgo/node_modules/mdn-data": {
-            "version": "2.0.30",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-            "dev": true,
-            "license": "CC0-1.0"
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true
         },
         "node_modules/postcss-svgo/node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/postcss-svgo/node_modules/svgo": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-            "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+            "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
             "dev": true,
             "dependencies": {
-                "commander": "^7.2.0",
+                "commander": "^11.1.0",
                 "css-select": "^5.1.0",
-                "css-tree": "^2.3.1",
+                "css-tree": "^3.0.1",
                 "css-what": "^6.1.0",
                 "csso": "^5.0.5",
-                "picocolors": "^1.0.0",
+                "picocolors": "^1.1.1",
                 "sax": "^1.5.0"
             },
             "bin": {
-                "svgo": "bin/svgo"
+                "svgo": "bin/svgo.js"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16"
             },
             "funding": {
                 "type": "opencollective",
@@ -11670,13 +11631,12 @@
             }
         },
         "node_modules/postcss-unique-selectors": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.4.tgz",
-            "integrity": "sha512-pmlZjsmEAG7cHd7uK3ZiNSW6otSZ13RHuZ/4cDN/bVglS5EpF2r2oxY99SuOHa8m7AWoBCelTS3JPpzsIs8skQ==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.5.tgz",
+            "integrity": "sha512-3QoYmEt4qg/rUWDn6Tc8+ZVPmbp4G1hXDtCNWDx0st8SjtCbRcxRXDDM1QrEiXGG3A45zscSJFb4QH90LViyxg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "postcss-selector-parser": "^7.1.0"
+                "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -13618,14 +13578,13 @@
             }
         },
         "node_modules/stylehacks": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.5.tgz",
-            "integrity": "sha512-5kNb7V37BNf0Q3w+1pxfa+oiNPS++/b4Jil9e/kPDgrk1zjEd6uR7SZeJiYaLYH6RRSC1XX2/37OTeU/4FvuIA==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.8.tgz",
+            "integrity": "sha512-I3f053GBLIiS5Fg6OMFhq/c+yW+5Hc2+1fgq7gElDMMSqwlRb3tBf2ef6ucLStYRpId4q//bQO1FjcyNyy4yDQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.5",
-                "postcss-selector-parser": "^7.1.0"
+                "browserslist": "^4.28.1",
+                "postcss-selector-parser": "^7.1.1"
             },
             "engines": {
                 "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -14409,9 +14368,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "funding": [
                 {
@@ -14427,7 +14386,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -14443,8 +14401,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true,
-            "license": "ISC"
+            "dev": true
         },
         "node_modules/urix": {
             "version": "0.1.0",
@@ -15976,6 +15933,12 @@
                 "@babel/helper-validator-identifier": "^7.27.1"
             }
         },
+        "@colordx/core": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.0.0.tgz",
+            "integrity": "sha512-twwxohWH8hWWh5ZJ5z6ZNn/JyMrq08K+NzxXKVGTpH+XmMPDAYYzqvszc3OPhYhqqxmfnbCSa/YHcS7pCnChmw==",
+            "dev": true
+        },
         "@gulp-sourcemaps/identity-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
@@ -16799,6 +16762,12 @@
             "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
             "dev": true
         },
+        "baseline-browser-mapping": {
+            "version": "2.10.12",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+            "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+            "dev": true
+        },
         "batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -17379,15 +17348,16 @@
             }
         },
         "browserslist": {
-            "version": "4.24.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-            "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001716",
-                "electron-to-chromium": "^1.5.149",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.3"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             }
         },
         "bs-recipes": {
@@ -17611,9 +17581,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001717",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-            "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+            "version": "1.0.30001782",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
+            "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
             "dev": true
         },
         "caw": {
@@ -17794,12 +17764,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "dev": true
-        },
-        "colord": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-            "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
             "dev": true
         },
         "combine-source-map": {
@@ -18098,9 +18062,9 @@
             }
         },
         "css-declaration-sorter": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
-            "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
+            "integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
             "dev": true,
             "requires": {}
         },
@@ -18157,51 +18121,51 @@
             "dev": true
         },
         "cssnano": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.7.tgz",
-            "integrity": "sha512-evKu7yiDIF7oS+EIpwFlMF730ijRyLFaM2o5cTxRGJR9OKHKkc+qP443ZEVR9kZG0syaAJJCPJyfv5pbrxlSng==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.4.tgz",
+            "integrity": "sha512-T9PNS7y+5Nc9Qmu9mRONqfxG1RVY7Vuvky0XN6MZ+9hqplesTEwnj9r0ROtVuSwUVfaDhVlavuzWIVLUgm4hkQ==",
             "dev": true,
             "requires": {
-                "cssnano-preset-default": "^7.0.7",
+                "cssnano-preset-default": "^7.0.12",
                 "lilconfig": "^3.1.3"
             }
         },
         "cssnano-preset-default": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.7.tgz",
-            "integrity": "sha512-jW6CG/7PNB6MufOrlovs1TvBTEVmhY45yz+bd0h6nw3h6d+1e+/TX+0fflZ+LzvZombbT5f+KC063w9VoHeHow==",
+            "version": "7.0.12",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.12.tgz",
+            "integrity": "sha512-B3Eoouzw/sl2zANI0AL9KbacummJTCww+fkHaDBMZad/xuVx8bUduPLly6hKVQAlrmvYkS1jB1CVQEKm3gn0AA==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "css-declaration-sorter": "^7.2.0",
                 "cssnano-utils": "^5.0.1",
                 "postcss-calc": "^10.1.1",
-                "postcss-colormin": "^7.0.3",
-                "postcss-convert-values": "^7.0.5",
-                "postcss-discard-comments": "^7.0.4",
+                "postcss-colormin": "^7.0.7",
+                "postcss-convert-values": "^7.0.9",
+                "postcss-discard-comments": "^7.0.6",
                 "postcss-discard-duplicates": "^7.0.2",
                 "postcss-discard-empty": "^7.0.1",
                 "postcss-discard-overridden": "^7.0.1",
                 "postcss-merge-longhand": "^7.0.5",
-                "postcss-merge-rules": "^7.0.5",
+                "postcss-merge-rules": "^7.0.8",
                 "postcss-minify-font-values": "^7.0.1",
-                "postcss-minify-gradients": "^7.0.1",
-                "postcss-minify-params": "^7.0.3",
-                "postcss-minify-selectors": "^7.0.5",
+                "postcss-minify-gradients": "^7.0.2",
+                "postcss-minify-params": "^7.0.6",
+                "postcss-minify-selectors": "^7.0.6",
                 "postcss-normalize-charset": "^7.0.1",
                 "postcss-normalize-display-values": "^7.0.1",
                 "postcss-normalize-positions": "^7.0.1",
                 "postcss-normalize-repeat-style": "^7.0.1",
                 "postcss-normalize-string": "^7.0.1",
                 "postcss-normalize-timing-functions": "^7.0.1",
-                "postcss-normalize-unicode": "^7.0.3",
+                "postcss-normalize-unicode": "^7.0.6",
                 "postcss-normalize-url": "^7.0.1",
                 "postcss-normalize-whitespace": "^7.0.1",
                 "postcss-ordered-values": "^7.0.2",
-                "postcss-reduce-initial": "^7.0.3",
+                "postcss-reduce-initial": "^7.0.6",
                 "postcss-reduce-transforms": "^7.0.1",
-                "postcss-svgo": "^7.0.2",
-                "postcss-unique-selectors": "^7.0.4"
+                "postcss-svgo": "^7.1.1",
+                "postcss-unique-selectors": "^7.0.5"
             }
         },
         "cssnano-utils": {
@@ -18757,9 +18721,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.5.150",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz",
-            "integrity": "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==",
+            "version": "1.5.329",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
+            "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
             "dev": true
         },
         "elliptic": {
@@ -22474,9 +22438,9 @@
             "optional": true
         },
         "node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "version": "2.0.36",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
             "dev": true
         },
         "normalize-package-data": {
@@ -23169,34 +23133,34 @@
             }
         },
         "postcss-colormin": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.3.tgz",
-            "integrity": "sha512-xZxQcSyIVZbSsl1vjoqZAcMYYdnJsIyG8OvqShuuqf12S88qQboxxEy0ohNCOLwVPXTU+hFHvJPACRL2B5ohTA==",
+            "version": "7.0.7",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.7.tgz",
+            "integrity": "sha512-sBQ628lSj3VQpDquQel8Pen5mmjFPsO4pH9lDLaHB1AVkMRHtkl0pRB5DCWznc9upWsxint/kV+AveSj7W1tew==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.5",
+                "@colordx/core": "^5.0.0",
+                "browserslist": "^4.28.1",
                 "caniuse-api": "^3.0.0",
-                "colord": "^2.9.3",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-convert-values": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.5.tgz",
-            "integrity": "sha512-0VFhH8nElpIs3uXKnVtotDJJNX0OGYSZmdt4XfSfvOMrFw1jKfpwpZxfC4iN73CTM/MWakDEmsHQXkISYj4BXw==",
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.9.tgz",
+            "integrity": "sha512-l6uATQATZaCa0bckHV+r6dLXfWtUBKXxO3jK+AtxxJJtgMPD+VhhPCCx51I4/5w8U5uHV67g3w7PXj+V3wlMlg==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-discard-comments": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.4.tgz",
-            "integrity": "sha512-6tCUoql/ipWwKtVP/xYiFf1U9QgJ0PUvxN7pTcsQ8Ns3Fnwq1pU5D5s1MhT/XySeLq6GXNvn37U46Ded0TckWg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.6.tgz",
+            "integrity": "sha512-Sq+Fzj1Eg5/CPf1ERb0wS1Im5cvE2gDXCE+si4HCn1sf+jpQZxDI4DXEp8t77B/ImzDceWE2ebJQFXdqZ6GRJw==",
             "dev": true,
             "requires": {
-                "postcss-selector-parser": "^7.1.0"
+                "postcss-selector-parser": "^7.1.1"
             }
         },
         "postcss-discard-duplicates": {
@@ -23248,15 +23212,15 @@
             }
         },
         "postcss-merge-rules": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.5.tgz",
-            "integrity": "sha512-ZonhuSwEaWA3+xYbOdJoEReKIBs5eDiBVLAGpYZpNFPzXZcEE5VKR7/qBEQvTZpiwjqhhqEQ+ax5O3VShBj9Wg==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.8.tgz",
+            "integrity": "sha512-BOR1iAM8jnr7zoQSlpeBmCsWV5Uudi/+5j7k05D0O/WP3+OFMPD86c1j/20xiuRtyt45bhxw/7hnhZNhW2mNFA==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "caniuse-api": "^3.0.0",
                 "cssnano-utils": "^5.0.1",
-                "postcss-selector-parser": "^7.1.0"
+                "postcss-selector-parser": "^7.1.1"
             }
         },
         "postcss-minify-font-values": {
@@ -23269,35 +23233,35 @@
             }
         },
         "postcss-minify-gradients": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.1.tgz",
-            "integrity": "sha512-X9JjaysZJwlqNkJbUDgOclyG3jZEpAMOfof6PUZjPnPrePnPG62pS17CjdM32uT1Uq1jFvNSff9l7kNbmMSL2A==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.2.tgz",
+            "integrity": "sha512-fVY3AB8Um7SJR5usHqTY2Ngf9qh8IRN+FFzrBP0ONJy6yYXsP7xyjK2BvSAIrpgs1cST+H91V0TXi3diHLYJtw==",
             "dev": true,
             "requires": {
-                "colord": "^2.9.3",
+                "@colordx/core": "^5.0.0",
                 "cssnano-utils": "^5.0.1",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-minify-params": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.3.tgz",
-            "integrity": "sha512-vUKV2+f5mtjewYieanLX0xemxIp1t0W0H/D11u+kQV/MWdygOO7xPMkbK+r9P6Lhms8MgzKARF/g5OPXhb8tgg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.6.tgz",
+            "integrity": "sha512-YOn02gC68JijlaXVuKvFSCvQOhTpblkcfDre2hb/Aaa58r2BIaK4AtE/cyZf2wV7YKAG+UlP9DT+By0ry1E4VQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "cssnano-utils": "^5.0.1",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-minify-selectors": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.5.tgz",
-            "integrity": "sha512-x2/IvofHcdIrAm9Q+p06ZD1h6FPcQ32WtCRVodJLDR+WMn8EVHI1kvLxZuGKz/9EY5nAmI6lIQIrpo4tBy5+ug==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.6.tgz",
+            "integrity": "sha512-lIbC0jy3AAwDxEgciZlBullDiMBeBCT+fz5G8RcA9MWqh/hfUkpOI3vNDUNEZHgokaoiv0juB9Y8fGcON7rU/A==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
-                "postcss-selector-parser": "^7.1.0"
+                "postcss-selector-parser": "^7.1.1"
             }
         },
         "postcss-normalize-charset": {
@@ -23353,12 +23317,12 @@
             }
         },
         "postcss-normalize-unicode": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.3.tgz",
-            "integrity": "sha512-EcoA29LvG3F+EpOh03iqu+tJY3uYYKzArqKJHxDhUYLa2u58aqGq16K6/AOsXD9yqLN8O6y9mmePKN5cx6krOw==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.6.tgz",
+            "integrity": "sha512-z6bwTV84YW6ZvvNoaNLuzRW4/uWxDKYI1iIDrzk6D2YTL7hICApy+Q1LP6vBEsljX8FM7YSuV9qI79XESd4ddQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "postcss-value-parser": "^4.2.0"
             }
         },
@@ -23391,12 +23355,12 @@
             }
         },
         "postcss-reduce-initial": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.3.tgz",
-            "integrity": "sha512-RFvkZaqiWtGMlVjlUHpaxGqEL27lgt+Q2Ixjf83CRAzqdo+TsDyGPtJUbPx2MuYIJ+sCQc2TrOvRnhcXQfgIVA==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.6.tgz",
+            "integrity": "sha512-G6ZyK68AmrPdMB6wyeA37ejnnRG2S8xinJrZJnOv+IaRKf6koPAVbQsiC7MfkmXaGmF1UO+QCijb27wfpxuRNg==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.5",
+                "browserslist": "^4.28.1",
                 "caniuse-api": "^3.0.0"
             }
         },
@@ -23410,9 +23374,9 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-            "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
@@ -23420,25 +23384,25 @@
             }
         },
         "postcss-svgo": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.0.2.tgz",
-            "integrity": "sha512-5Dzy66JlnRM6pkdOTF8+cGsB1fnERTE8Nc+Eed++fOWo1hdsBptCsbG8UuJkgtZt75bRtMJIrPeZmtfANixdFA==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.1.tgz",
+            "integrity": "sha512-zU9H9oEDrUFKa0JB7w+IYL7Qs9ey1mZyjhbf0KLxwJDdDRtoPvCmaEfknzqfHj44QS9VD6c5sJnBAVYTLRg/Sg==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0",
-                "svgo": "^3.3.2"
+                "svgo": "^4.0.1"
             },
             "dependencies": {
                 "commander": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-                    "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+                    "version": "11.1.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+                    "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
                     "dev": true
                 },
                 "css-select": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-                    "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+                    "version": "5.2.2",
+                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+                    "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
                     "dev": true,
                     "requires": {
                         "boolbase": "^1.0.0",
@@ -23449,13 +23413,13 @@
                     }
                 },
                 "css-tree": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-                    "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+                    "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
                     "dev": true,
                     "requires": {
-                        "mdn-data": "2.0.30",
-                        "source-map-js": "^1.0.1"
+                        "mdn-data": "2.27.1",
+                        "source-map-js": "^1.2.1"
                     }
                 },
                 "csso": {
@@ -23523,9 +23487,9 @@
                     "dev": true
                 },
                 "mdn-data": {
-                    "version": "2.0.30",
-                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-                    "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+                    "version": "2.27.1",
+                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+                    "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
                     "dev": true
                 },
                 "picocolors": {
@@ -23535,29 +23499,29 @@
                     "dev": true
                 },
                 "svgo": {
-                    "version": "3.3.3",
-                    "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-                    "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+                    "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
                     "dev": true,
                     "requires": {
-                        "commander": "^7.2.0",
+                        "commander": "^11.1.0",
                         "css-select": "^5.1.0",
-                        "css-tree": "^2.3.1",
+                        "css-tree": "^3.0.1",
                         "css-what": "^6.1.0",
                         "csso": "^5.0.5",
-                        "picocolors": "^1.0.0",
+                        "picocolors": "^1.1.1",
                         "sax": "^1.5.0"
                     }
                 }
             }
         },
         "postcss-unique-selectors": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.4.tgz",
-            "integrity": "sha512-pmlZjsmEAG7cHd7uK3ZiNSW6otSZ13RHuZ/4cDN/bVglS5EpF2r2oxY99SuOHa8m7AWoBCelTS3JPpzsIs8skQ==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.5.tgz",
+            "integrity": "sha512-3QoYmEt4qg/rUWDn6Tc8+ZVPmbp4G1hXDtCNWDx0st8SjtCbRcxRXDDM1QrEiXGG3A45zscSJFb4QH90LViyxg==",
             "dev": true,
             "requires": {
-                "postcss-selector-parser": "^7.1.0"
+                "postcss-selector-parser": "^7.1.1"
             }
         },
         "postcss-value-parser": {
@@ -25094,13 +25058,13 @@
             }
         },
         "stylehacks": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.5.tgz",
-            "integrity": "sha512-5kNb7V37BNf0Q3w+1pxfa+oiNPS++/b4Jil9e/kPDgrk1zjEd6uR7SZeJiYaLYH6RRSC1XX2/37OTeU/4FvuIA==",
+            "version": "7.0.8",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.8.tgz",
+            "integrity": "sha512-I3f053GBLIiS5Fg6OMFhq/c+yW+5Hc2+1fgq7gElDMMSqwlRb3tBf2ef6ucLStYRpId4q//bQO1FjcyNyy4yDQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.24.5",
-                "postcss-selector-parser": "^7.1.0"
+                "browserslist": "^4.28.1",
+                "postcss-selector-parser": "^7.1.1"
             }
         },
         "subarg": {
@@ -25697,9 +25661,9 @@
             "dev": true
         },
         "update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "requires": {
                 "escalade": "^3.2.0",

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -26,7 +26,7 @@
                 "gulp-error-handle": "1.0.1",
                 "gulp-filter": "9.0.1",
                 "gulp-if": "3.0.0",
-                "gulp-imagemin": "9.1.0",
+                "gulp-imagemin": "9.2.0",
                 "gulp-postcss": "10.0.0",
                 "gulp-rename": "2.1.0",
                 "gulp-sass": "5.1.0",
@@ -7462,9 +7462,9 @@
             }
         },
         "node_modules/gulp-imagemin": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-9.1.0.tgz",
-            "integrity": "sha512-PmzTWoNrVMYVN4ObRdHyt6oer4mqxV53IbCDi3Q8EHeDZW0OzAuh6RlOtpd/R7PFmbDUk64q5P+L04fD9I5cVA==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-9.2.0.tgz",
+            "integrity": "sha512-y7yAHTUzfHHq6njHY2OIvLOcffF1I/ULSlfzunnIvPeNNpYDArwrlqCzPvnN4Le0p3H/1ERAAQJJPMhbnTRnFQ==",
             "dev": true,
             "dependencies": {
                 "chalk": "^5.3.0",
@@ -20585,9 +20585,9 @@
             }
         },
         "gulp-imagemin": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-9.1.0.tgz",
-            "integrity": "sha512-PmzTWoNrVMYVN4ObRdHyt6oer4mqxV53IbCDi3Q8EHeDZW0OzAuh6RlOtpd/R7PFmbDUk64q5P+L04fD9I5cVA==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-9.2.0.tgz",
+            "integrity": "sha512-y7yAHTUzfHHq6njHY2OIvLOcffF1I/ULSlfzunnIvPeNNpYDArwrlqCzPvnN4Le0p3H/1ERAAQJJPMhbnTRnFQ==",
             "dev": true,
             "requires": {
                 "chalk": "^5.3.0",

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -41,7 +41,7 @@
                 "popper.js": "1.16.1",
                 "postcss": "8.5.8",
                 "postcss-flexbugs-fixes": "5.0.2",
-                "sass": "1.98.0",
+                "sass": "1.99.0",
                 "vinyl-buffer": "1.0.1",
                 "yargs": "17.7.2"
             },
@@ -12386,9 +12386,9 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.98.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
-            "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
+            "version": "1.99.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+            "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
             "dev": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
@@ -24135,9 +24135,9 @@
             "dev": true
         },
         "sass": {
-            "version": "1.98.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
-            "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
+            "version": "1.99.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+            "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
             "dev": true,
             "requires": {
                 "@parcel/watcher": "^2.4.1",

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -4013,13 +4013,16 @@
             }
         },
         "node_modules/cipher-base": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+            "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
             "dev": true,
             "dependencies": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/class-utils": {
@@ -17669,13 +17672,13 @@
             }
         },
         "cipher-base": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+            "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1"
             }
         },
         "class-utils": {

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -9418,9 +9418,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "dev": true
         },
         "node_modules/lodash.clonedeep": {
@@ -21903,9 +21903,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "dev": true
         },
         "lodash.clonedeep": {

--- a/csfieldguide/package-lock.json
+++ b/csfieldguide/package-lock.json
@@ -2172,15 +2172,6 @@
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "dev": true
         },
-        "node_modules/@trysound/sax": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-            "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/@types/cookie": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -11655,19 +11646,18 @@
             "license": "ISC"
         },
         "node_modules/postcss-svgo/node_modules/svgo": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-            "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
+            "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
                 "css-select": "^5.1.0",
                 "css-tree": "^2.3.1",
                 "css-what": "^6.1.0",
                 "csso": "^5.0.5",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.0.0",
+                "sax": "^1.5.0"
             },
             "bin": {
                 "svgo": "bin/svgo"
@@ -12502,6 +12492,15 @@
             "funding": {
                 "type": "individual",
                 "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "dev": true,
+            "engines": {
+                "node": ">=11.0.0"
             }
         },
         "node_modules/seek-bzip": {
@@ -13697,18 +13696,18 @@
             }
         },
         "node_modules/svgo": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-            "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
+            "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
             "dev": true,
             "optional": true,
             "dependencies": {
-                "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
                 "css-select": "^4.1.3",
                 "css-tree": "^1.1.3",
                 "csso": "^4.2.0",
                 "picocolors": "^1.0.0",
+                "sax": "^1.5.0",
                 "stable": "^0.1.8"
             },
             "bin": {
@@ -16252,12 +16251,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-            "dev": true
-        },
-        "@trysound/sax": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-            "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
             "dev": true
         },
         "@types/cookie": {
@@ -23543,18 +23536,18 @@
                     "dev": true
                 },
                 "svgo": {
-                    "version": "3.3.2",
-                    "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-                    "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+                    "version": "3.3.3",
+                    "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
+                    "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
                     "dev": true,
                     "requires": {
-                        "@trysound/sax": "0.2.0",
                         "commander": "^7.2.0",
                         "css-select": "^5.1.0",
                         "css-tree": "^2.3.1",
                         "css-what": "^6.1.0",
                         "csso": "^5.0.5",
-                        "picocolors": "^1.0.0"
+                        "picocolors": "^1.0.0",
+                        "sax": "^1.5.0"
                     }
                 }
             }
@@ -24192,6 +24185,12 @@
                     "dev": true
                 }
             }
+        },
+        "sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "dev": true
         },
         "seek-bzip": {
             "version": "1.0.6",
@@ -25150,18 +25149,18 @@
             }
         },
         "svgo": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-            "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
+            "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
             "dev": true,
             "optional": true,
             "requires": {
-                "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
                 "css-select": "^4.1.3",
                 "css-tree": "^1.1.3",
                 "csso": "^4.2.0",
                 "picocolors": "^1.0.0",
+                "sax": "^1.5.0",
                 "stable": "^0.1.8"
             },
             "dependencies": {

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -48,7 +48,7 @@
         "last 2 versions"
     ],
     "scripts": {
-        "dev": "gulp",
+        "dev": "gulp --no-experimental-require-module",
         "generate-assets": "gulp generate-assets --no-experimental-require-module",
         "build": "gulp generate-assets --production --no-experimental-require-module"
     }

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -7,7 +7,7 @@
         "@babel/core": "^7.27.7",
         "@babel/preset-env": "^7.27.2",
         "ansi-colors": "4.1.3",
-        "autoprefixer": "10.4.21",
+        "autoprefixer": "10.4.27",
         "babelify": "^10.0.0",
         "bootstrap": "4.6.2",
         "browser-sync": "3.0.4",

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "devDependencies": {
         "@babel/core": "^7.27.7",
-        "@babel/preset-env": "^7.27.2",
+        "@babel/preset-env": "^7.29.2",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.21",
         "babelify": "^10.0.0",

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -4,7 +4,7 @@
     "main": "gulpfile.mjs",
     "private": true,
     "devDependencies": {
-        "@babel/core": "^7.27.7",
+        "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.2",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.27",

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -37,7 +37,7 @@
         "popper.js": "1.16.1",
         "postcss": "8.5.6",
         "postcss-flexbugs-fixes": "5.0.2",
-        "sass": "1.89.2",
+        "sass": "1.98.0",
         "vinyl-buffer": "1.0.1",
         "yargs": "17.7.2"
     },

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -37,7 +37,7 @@
         "popper.js": "1.16.1",
         "postcss": "8.5.8",
         "postcss-flexbugs-fixes": "5.0.2",
-        "sass": "1.98.0",
+        "sass": "1.99.0",
         "vinyl-buffer": "1.0.1",
         "yargs": "17.7.2"
     },

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -22,7 +22,7 @@
         "gulp-error-handle": "1.0.1",
         "gulp-filter": "9.0.1",
         "gulp-if": "3.0.0",
-        "gulp-imagemin": "9.1.0",
+        "gulp-imagemin": "9.2.0",
         "gulp-postcss": "10.0.0",
         "gulp-rename": "2.1.0",
         "gulp-sass": "5.1.0",

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -13,7 +13,7 @@
         "browser-sync": "3.0.4",
         "browserify": "17.0.1",
         "codemirror": "5.65.6",
-        "cssnano": "7.0.7",
+        "cssnano": "7.1.4",
         "details-element-polyfill": "2.4.0",
         "fancy-log": "2.0.0",
         "gulp": "4.0.2",

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -29,7 +29,7 @@
         "gulp-sourcemaps": "3.0.0",
         "gulp-tap": "2.0.0",
         "gulp-terser": "2.1.0",
-        "iframe-resizer": "4.4.5",
+        "iframe-resizer": "5.5.9",
         "jquery": "3.7.1",
         "lity": "2.4.1",
         "multiple-select": "1.7.0",

--- a/csfieldguide/package.json
+++ b/csfieldguide/package.json
@@ -35,7 +35,7 @@
         "multiple-select": "1.7.0",
         "pixrem": "5.0.0",
         "popper.js": "1.16.1",
-        "postcss": "8.5.6",
+        "postcss": "8.5.8",
         "postcss-flexbugs-fixes": "5.0.2",
         "sass": "1.89.2",
         "vinyl-buffer": "1.0.1",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,56 @@ All notable changes to this project will be documented in this file.
 We have listed major changes for each release below.
 `All downloads are available on GitHub <https://github.com/uccser/cs-field-guide/releases/>`__
 
+3.17.0
+==============================================================================
+
+**Release date:** 8th April 2026
+
+**Changelog:**
+
+- Start initial work on Te Reo Māori translations.
+- Fix broken YouTube embeds.
+- Fix bug that that broke the Gulp pipeline on newer Node 20 and 22 versions.
+
+- Core dependency changes:
+
+  - Update @babel/core from 7.27.7 to 7.29.0.
+  - Update @babel/preset-env from 7.27.2 to 7.29.2.
+  - Update actions/checkout from 4 to 6.
+  - Update actions/setup-python from 5 to 6.
+  - Update autoprefixer from 10.4.21 to 10.4.27.
+  - Update cipher-base from 1.0.4 to 1.0.6.
+  - Update codecov/codecov-action from 4 to 6.
+  - Update coverage from 7.9.1 to 7.13.5.
+  - Update crowdin/github-action from 1.20.4 to 2.16.0.
+  - Update cssnano from 7.0.7 to 7.1.4.
+  - Update cssselect from 1.3.0 to 1.4.0.
+  - Update django from 4.2.22 to 4.2.29.
+  - Update django-cors-headers from 4.7.0 to 4.9.0.
+  - Update django-debug-toolbar from 4.4.6 to 6.2.0.
+  - Update django-environ from 0.12.0 to 0.13.0.
+  - Update django-statici18n from 2.6.0 to 2.7.1.
+  - Update docker/build-push-action from 5.4.0 to 7.0.0.
+  - Update docker/login-action from 3.4.0 to 4.1.0.
+  - Update docker/metadata-action from 5 to 6.
+  - Update gulp-imagemin from 9.1.0 to 9.2.0.
+  - Update gunicorn from 22.0.0 to 25.3.0.
+  - Update iframe-resizer from 4.4.5 to 5.5.9.
+  - Update lodash from 4.17.21 to 4.17.23.
+  - Update lxml from 5.4.0 to 6.0.2.
+  - Update picomatch from 2.3.1 to 2.3.2.
+  - Update postcss from 8.5.6 to 8.5.8.
+  - Update psycopg2 from 2.9.10 to 2.9.11.
+  - Update pygments from 2.19.2 to 2.20.0.
+  - Update python-bidi from 0.6.6 to 0.6.7.
+  - Update pyyaml from 6.0.2 to 6.0.3.
+  - Update sass from 1.89.2 to 1.99.0.
+  - Update selenium from 4.33.0 to 4.41.0.
+  - Update sha.js from 2.4.11 to 2.4.12.
+  - Update uniseg from 0.10.0 to 0.10.1.
+  - Update verto from 1.1.1 to 1.2.0.
+  - Update whitenoise from 6.9.0 to 6.12.0.
+
 3.16.0
 ==============================================================================
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ django-environ==0.13.0
 django-bootstrap-breadcrumbs==0.9.2
 
 # Web serving
-gunicorn==22.0.0
+gunicorn==25.3.0
 whitenoise==6.12.0
 
 # Database APIs

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ django-bootstrap-breadcrumbs==0.9.2
 
 # Web serving
 gunicorn==22.0.0
-whitenoise==6.9.0
+whitenoise==6.12.0
 
 # Database APIs
 psycopg2==2.9.10

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # Django
 django==4.2.29
-django-environ==0.12.0
+django-environ==0.13.0
 django-bootstrap-breadcrumbs==0.9.2
 
 # Web serving

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Django
-django==4.2.28
+django==4.2.29
 django-environ==0.12.0
 django-bootstrap-breadcrumbs==0.9.2
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ django-modeltranslation==0.19.15
 uniseg==0.10.0
 python-bidi==0.6.6
 django-bidi-utils==1.0
-django-statici18n==2.6.0
+django-statici18n==2.7.1
 
 # CORS
 django-cors-headers==4.7.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-inline-svg==0.1.1
 selenium==4.33.0
 
 # Markdown
-verto==1.1.1
+verto==1.2.0
 Pygments==2.20.0
 python-markdown-math==0.6
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ lxml==5.4.0
 cssselect==1.3.0
 
 # YAML Loading
-PyYAML==6.0.2
+PyYAML==6.0.3
 
 # I18n
 django-modeltranslation==0.19.15

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ psycopg2==2.9.10
 
 # Images
 django-inline-svg==0.1.1
-selenium==4.33.0
+selenium==4.41.0
 
 # Markdown
 verto==1.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ PyYAML==6.0.3
 # I18n
 django-modeltranslation==0.19.15
 uniseg==0.10.1
-python-bidi==0.6.6
+python-bidi==0.6.7
 django-bidi-utils==1.0
 django-statici18n==2.7.1
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ Pygments==2.20.0
 python-markdown-math==0.6
 
 # XML Parsing
-lxml==5.4.0
+lxml==6.0.2
 cssselect==1.4.0
 
 # YAML Loading

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,4 +34,4 @@ django-bidi-utils==1.0
 django-statici18n==2.6.0
 
 # CORS
-django-cors-headers==4.7.0
+django-cors-headers==4.9.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ python-markdown-math==0.6
 
 # XML Parsing
 lxml==5.4.0
-cssselect==1.3.0
+cssselect==1.4.0
 
 # YAML Loading
 PyYAML==6.0.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ selenium==4.33.0
 
 # Markdown
 verto==1.1.1
-Pygments==2.19.2
+Pygments==2.20.0
 python-markdown-math==0.6
 
 # XML Parsing

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ gunicorn==22.0.0
 whitenoise==6.9.0
 
 # Database APIs
-psycopg2==2.9.10
+psycopg2==2.9.11
 
 # Images
 django-inline-svg==0.1.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Django
-django==4.2.22
+django==4.2.28
 django-environ==0.12.0
 django-bootstrap-breadcrumbs==0.9.2
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ PyYAML==6.0.2
 
 # I18n
 django-modeltranslation==0.19.15
-uniseg==0.10.0
+uniseg==0.10.1
 python-bidi==0.6.6
 django-bidi-utils==1.0
 django-statici18n==2.6.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,4 +3,4 @@
 -r test.txt
 
 # Debugging Tools
-django-debug-toolbar==4.4.6
+django-debug-toolbar==6.2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@ flake8==7.3.0
 pydocstyle==6.3.0
 
 #Coverage Tools
-coverage==7.9.1
+coverage==7.13.5
 
 # Skip migration files for local testing
 django-test-without-migrations==0.6


### PR DESCRIPTION
## Proposed changes
- Start initial work on Te Reo Māori translations.
- Fix broken YouTube embeds.
- Fix bug that that broke the Gulp pipeline on newer Node 20 and 22 versions.

- Core dependency changes:

  - Update @babel/core from 7.27.7 to 7.29.0.
  - Update @babel/preset-env from 7.27.2 to 7.29.2.
  - Update actions/checkout from 4 to 6.
  - Update actions/setup-python from 5 to 6.
  - Update autoprefixer from 10.4.21 to 10.4.27.
  - Update cipher-base from 1.0.4 to 1.0.6.
  - Update codecov/codecov-action from 4 to 6.
  - Update coverage from 7.9.1 to 7.13.5.
  - Update crowdin/github-action from 1.20.4 to 2.16.0.
  - Update cssnano from 7.0.7 to 7.1.4.
  - Update cssselect from 1.3.0 to 1.4.0.
  - Update django from 4.2.22 to 4.2.29.
  - Update django-cors-headers from 4.7.0 to 4.9.0.
  - Update django-debug-toolbar from 4.4.6 to 6.2.0.
  - Update django-environ from 0.12.0 to 0.13.0.
  - Update django-statici18n from 2.6.0 to 2.7.1.
  - Update docker/build-push-action from 5.4.0 to 7.0.0.
  - Update docker/login-action from 3.4.0 to 4.1.0.
  - Update docker/metadata-action from 5 to 6.
  - Update gulp-imagemin from 9.1.0 to 9.2.0.
  - Update gunicorn from 22.0.0 to 25.3.0.
  - Update iframe-resizer from 4.4.5 to 5.5.9.
  - Update lodash from 4.17.21 to 4.17.23.
  - Update lxml from 5.4.0 to 6.0.2.
  - Update picomatch from 2.3.1 to 2.3.2.
  - Update postcss from 8.5.6 to 8.5.8.
  - Update psycopg2 from 2.9.10 to 2.9.11.
  - Update pygments from 2.19.2 to 2.20.0.
  - Update python-bidi from 0.6.6 to 0.6.7.
  - Update pyyaml from 6.0.2 to 6.0.3.
  - Update sass from 1.89.2 to 1.99.0.
  - Update selenium from 4.33.0 to 4.41.0.
  - Update sha.js from 2.4.11 to 2.4.12.
  - Update uniseg from 0.10.0 to 0.10.1.
  - Update verto from 1.1.1 to 1.2.0.
  - Update whitenoise from 6.9.0 to 6.12.0.
